### PR TITLE
Add helper for creating DataFrame and writing to Parquet

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -243,7 +243,7 @@ impl eframe::App for ParquetApp {
                     Operation::Create => {
                         if let Ok(df) = build_dataframe(&self.schema, &self.rows) {
                             if !self.save_path.is_empty() {
-                                let _ = parquet_examples::write_dataframe_to_parquet(
+                                let _ = parquet_examples::create_and_write_parquet(
                                     &df,
                                     &self.save_path,
                                 );

--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -92,6 +92,14 @@ pub fn write_dataframe_to_parquet(df: &DataFrame, path: &str) -> Result<()> {
     Ok(())
 }
 
+/// Convenience wrapper which writes the provided [`DataFrame`] to the given path.
+///
+/// This simply forwards to [`write_dataframe_to_parquet`].  It exists so the
+/// GUI can create a `DataFrame` and immediately persist it using a single call.
+pub fn create_and_write_parquet(df: &DataFrame, path: &str) -> Result<()> {
+    write_dataframe_to_parquet(df, path)
+}
+
 /// Build a new [`DataFrame`] from a user provided schema and row data.
 ///
 /// The `schema` slice defines column names and their [`DataType`].  `rows`


### PR DESCRIPTION
## Summary
- introduce `create_and_write_parquet` helper
- use helper in Create mode of GUI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687edd8634188332886fe51caaf1fab1