### PR TITLE
Add sortable preview and temporal types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "Polars_Parquet_Learning"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "eframe",
  "egui",
  "parquet",
@@ -14,6 +15,7 @@ dependencies = [
  "rfd",
  "serde",
  "serde_derive",
+ "shlex",
  "tempfile",
  "tokio",
 ]
@@ -933,8 +935,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ rfd = "0.15"
 # Simplified error handling
 anyhow = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+chrono = "0.4"
+shlex = "1.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ the **Save** field will write the result as a Parquet file when **Run** is
 clicked. The helper function [`create_dataframe`](src/parquet_examples.rs) shows
 how to accomplish the same programmatically.
 
-Allowed column types are `int`/`i64`, `str`/`string`, `float`/`f64` and
-`bool`/`boolean`.
+Allowed column types are `int`/`i64`, `str`/`string`, `float`/`f64`,
+`bool`/`boolean`, `date`, `datetime` and `time`.
 


### PR DESCRIPTION
## Summary
- make DataFrame preview headers clickable for sorting
- support Date/Datetime/Time when parsing types
- handle temporal values when building DataFrames
- update README docs for new column types
- preserve quoted substrings in expression parser
- add tests for temporal types and quoted expressions

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68803b5aea448332835b5a0dc20c3e7b