### PR TITLE
Add DataFrame preview side panel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_derive = "1.0"
 # GUI framework built on egui
 eframe = "0.32"
 egui = "0.32"
+egui_extras = "0.32"
 
 # Native file dialogs
 rfd = "0.15"


### PR DESCRIPTION
## Summary
- add `egui_extras` dependency for table widgets
- show DataFrame `head()` preview and row count in a side panel
- add button to toggle schema display
- move preview table to the side panel using `TableBuilder`

## Testing
- `cargo test`

 