### PR TITLE
Add basic CLI interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "eframe",
- "egui",
+ "egui 0.32.0",
+ "egui_extras",
+ "egui_plot",
  "parquet",
  "polars",
  "rfd",
@@ -225,6 +228,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -949,8 +1002,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clipboard-win"
@@ -971,6 +1064,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -1252,12 +1351,21 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecolor"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
+dependencies = [
+ "emath 0.31.1",
+]
+
+[[package]]
+name = "ecolor"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a631732d995184114016fab22fc7e3faf73d6841c2d7650395fe251fbcd9285"
 dependencies = [
  "bytemuck",
- "emath",
+ "emath 0.32.0",
 ]
 
 [[package]]
@@ -1269,7 +1377,7 @@ dependencies = [
  "ahash",
  "bytemuck",
  "document-features",
- "egui",
+ "egui 0.32.0",
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
@@ -1298,6 +1406,20 @@ dependencies = [
 
 [[package]]
 name = "egui"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
+dependencies = [
+ "ahash",
+ "bitflags 2.9.1",
+ "emath 0.31.1",
+ "epaint 0.31.1",
+ "nohash-hasher",
+ "profiling",
+]
+
+[[package]]
+name = "egui"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8470210c95a42cc985d9ffebfd5067eea55bdb1c3f7611484907db9639675e28"
@@ -1305,8 +1427,8 @@ dependencies = [
  "accesskit",
  "ahash",
  "bitflags 2.9.1",
- "emath",
- "epaint",
+ "emath 0.32.0",
+ "epaint 0.32.0",
  "log",
  "nohash-hasher",
  "profiling",
@@ -1323,8 +1445,8 @@ dependencies = [
  "ahash",
  "bytemuck",
  "document-features",
- "egui",
- "epaint",
+ "egui 0.32.0",
+ "epaint 0.32.0",
  "log",
  "profiling",
  "thiserror 1.0.69",
@@ -1344,7 +1466,7 @@ dependencies = [
  "ahash",
  "arboard",
  "bytemuck",
- "egui",
+ "egui 0.32.0",
  "log",
  "profiling",
  "raw-window-handle",
@@ -1355,6 +1477,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_extras"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f791a5937f518249016b276b3639ad2aa3824048b6f2161ec2b431ab325880a"
+dependencies = [
+ "ahash",
+ "egui 0.32.0",
+ "enum-map",
+ "log",
+ "mime_guess2",
+ "profiling",
+]
+
+[[package]]
 name = "egui_glow"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,7 +1498,7 @@ checksum = "d44f3fd4fdc5f960c9e9ef7327c26647edc3141abf96102980647129d49358e6"
 dependencies = [
  "ahash",
  "bytemuck",
- "egui",
+ "egui 0.32.0",
  "glow",
  "log",
  "memoffset",
@@ -1373,10 +1509,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_plot"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ae092b46ea532f6c69d3e71036fb3b688fd00fd09c2a1e43d17051a8ae43e6"
+dependencies = [
+ "ahash",
+ "egui 0.31.1",
+ "emath 0.31.1",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "emath"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 
 [[package]]
 name = "emath"
@@ -1392,6 +1545,26 @@ name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1416,6 +1589,21 @@ dependencies = [
 
 [[package]]
 name = "epaint"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "ecolor 0.31.1",
+ "emath 0.31.1",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
+]
+
+[[package]]
+name = "epaint"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94cca02195f0552c17cabdc02f39aa9ab6fbd815dac60ab1cd3d5b0aa6f9551c"
@@ -1423,8 +1611,8 @@ dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
- "ecolor",
- "emath",
+ "ecolor 0.32.0",
+ "emath 0.32.0",
  "epaint_default_fonts",
  "log",
  "nohash-hasher",
@@ -2236,6 +2424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,6 +2711,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess2"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1706dc14a2e140dec0a7a07109d9a3d5890b81e85bd6c60b906b249a77adf0ca"
+dependencies = [
+ "mime",
+ "phf 0.11.3",
+ "phf_shared 0.11.3",
+ "unicase",
 ]
 
 [[package]]
@@ -3041,6 +3253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3159,11 +3377,55 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicase",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+ "unicase",
 ]
 
 [[package]]
@@ -4700,6 +4962,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5085,6 +5353,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5149,6 +5423,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ anyhow = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 chrono = "0.4"
 shlex = "1.3"
+clap = { version = "4", features = ["derive"] }
 
 # Optional plotting support
 egui_plot = { version = "0.32", optional = true }

--- a/README.md
+++ b/README.md
@@ -91,3 +91,18 @@ how to accomplish the same programmatically.
 Allowed column types are `int`/`i64`, `str`/`string`, `float`/`f64`,
 `bool`/`boolean`, `date`, `datetime` and `time`.
 
+## Command line
+
+Running the binary with additional arguments invokes a CLI instead of the GUI.
+Each subcommand mirrors one of the operations available in the application.
+
+```
+cargo run -- <SUBCOMMAND> [OPTIONS]
+```
+
+Example reading a file:
+
+```
+cargo run -- read path/to/file.parquet
+```
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,136 @@
+use crate::parquet_examples;
+use anyhow::Result;
+use clap::{Args, Parser, Subcommand};
+
+/// Top level command line arguments
+#[derive(Parser)]
+#[command(author, version, about)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Read a Parquet file and print the resulting DataFrame
+    Read(ReadArgs),
+    /// Modify records by appending `!` to each name
+    Modify(ModifyArgs),
+    /// Write a Parquet file to a new location
+    Write(WriteArgs),
+    /// Create a small example DataFrame and save it
+    Create(CreateArgs),
+    /// Partition a file by a column
+    Partition(PartitionArgs),
+    /// Query rows by prefix or expression
+    Query(QueryArgs),
+}
+
+#[derive(Args)]
+pub struct ReadArgs {
+    /// File to read
+    pub file: String,
+}
+
+#[derive(Args)]
+pub struct ModifyArgs {
+    /// File to modify
+    pub file: String,
+}
+
+#[derive(Args)]
+pub struct WriteArgs {
+    /// Input file
+    pub input: String,
+    /// Output file
+    pub output: String,
+}
+
+#[derive(Args)]
+pub struct CreateArgs {
+    /// Output Parquet file
+    pub output: String,
+}
+
+#[derive(Args)]
+pub struct PartitionArgs {
+    /// Input file
+    pub input: String,
+    /// Column to partition by
+    pub column: String,
+    /// Output directory
+    pub dir: String,
+}
+
+#[derive(Args)]
+pub struct QueryArgs {
+    /// Input file
+    pub input: String,
+    /// Filter by name prefix
+    #[arg(long)]
+    pub prefix: Option<String>,
+    /// Filter with a simple expression
+    #[arg(long)]
+    pub expr: Option<String>,
+}
+
+pub fn run(cli: Cli) -> Result<()> {
+    match cli.command {
+        Commands::Read(args) => cmd_read(&args.file),
+        Commands::Modify(args) => cmd_modify(&args.file),
+        Commands::Write(args) => cmd_write(&args.input, &args.output),
+        Commands::Create(args) => cmd_create(&args.output),
+        Commands::Partition(args) => cmd_partition(&args.input, &args.column, &args.dir),
+        Commands::Query(args) => {
+            cmd_query(&args.input, args.prefix.as_deref(), args.expr.as_deref())
+        }
+    }
+}
+
+fn cmd_read(file: &str) -> Result<()> {
+    let df = parquet_examples::read_parquet_to_dataframe(file)?;
+    println!("{}", df);
+    Ok(())
+}
+
+fn cmd_modify(file: &str) -> Result<()> {
+    let df = parquet_examples::read_parquet_to_dataframe(file)?;
+    let mut records = parquet_examples::dataframe_to_records(&df)?;
+    parquet_examples::modify_records(&mut records);
+    let df = parquet_examples::records_to_dataframe(&records)?;
+    println!("{}", df);
+    Ok(())
+}
+
+fn cmd_write(input: &str, output: &str) -> Result<()> {
+    let df = parquet_examples::read_parquet_to_dataframe(input)?;
+    parquet_examples::write_dataframe_to_parquet(&df, output)?;
+    println!("Wrote {output}");
+    Ok(())
+}
+
+fn cmd_create(output: &str) -> Result<()> {
+    use polars::prelude::*;
+    let df = df!("id" => &[1i64, 2], "name" => &["a", "b"])?;
+    parquet_examples::create_and_write_parquet(&df, output)?;
+    println!("Wrote {output}");
+    Ok(())
+}
+
+fn cmd_partition(input: &str, column: &str, dir: &str) -> Result<()> {
+    let df = parquet_examples::read_parquet_to_dataframe(input)?;
+    parquet_examples::write_partitioned(&df, &[column], dir)?;
+    println!("Wrote partitions to {dir}");
+    Ok(())
+}
+
+fn cmd_query(input: &str, prefix: Option<&str>, expr: Option<&str>) -> Result<()> {
+    let df = if let Some(expr) = expr {
+        parquet_examples::filter_with_expr(input, expr)?
+    } else {
+        let p = prefix.unwrap_or("");
+        parquet_examples::filter_by_name_prefix(input, p)?
+    };
+    println!("{}", df);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,12 @@
 
 // Expose example functions for GUI callbacks or tests.
 pub mod background;
+pub mod cli;
 pub mod parquet_examples;
 
 use anyhow::Result;
 use background::JobResult;
+use clap::Parser;
 use eframe::egui;
 use egui_extras::{Column as TableColumn, TableBuilder};
 #[cfg(feature = "plotting")]
@@ -861,6 +863,14 @@ impl eframe::App for ParquetApp {
 
 /// Entry point which launches the GUI application through `eframe`.
 fn main() -> eframe::Result<()> {
+    if std::env::args().len() > 1 {
+        let cli = cli::Cli::parse();
+        if let Err(e) = cli::run(cli) {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
     // `eframe` sets up a native window and integrates the `egui` event loop.
     let options = eframe::NativeOptions::default();
     eframe::run_native(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,21 @@
+use polars::prelude::*;
+use std::fs::File;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn cli_read_runs() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.parquet");
+    let mut df = df!("id" => &[1i64], "name" => &["a"]).unwrap();
+    ParquetWriter::new(File::create(&file).unwrap())
+        .finish(&mut df)
+        .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_Polars_Parquet_Learning");
+    let status = Command::new(exe)
+        .args(["read", file.to_str().unwrap()])
+        .status()
+        .expect("run");
+    assert!(status.success());
+}


### PR DESCRIPTION
## Summary
- add `clap` dependency
- implement a new `cli` module for command line use
- run CLI when arguments are provided otherwise launch the GUI
- document CLI usage
- add a test that spawns the binary with the `read` command

## Testing
- `cargo fmt`
- `cargo test` *(fails: process killed due to environment limits)*
 