### PR TITLE
Add DataFrame summarizer and UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Enabling the `plotting` feature will add a simple chart viewer using
 panel lets you pick a numeric column then choose between a histogram or line
 plot for that data.
 
+A small statistics table summarising the loaded `DataFrame` is also shown in the
+preview panel. It lists row/column counts along with the output of
+`DataFrame::describe` for quick inspection.
+
 ## Additional examples
 
 The `parquet_examples` module includes several helper functions that showcase

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,6 +370,48 @@ impl eframe::App for ParquetApp {
                         }
                     });
 
+                if let Ok(summary) = parquet_examples::summarize_dataframe(df) {
+                    ui.separator();
+                    ui.label("Statistics");
+                    ui.label(format!("Rows: {}", summary.rows));
+                    ui.label(format!("Columns: {}", summary.columns));
+
+                    let stat_names: Vec<String> = summary
+                        .stats
+                        .get_column_names()
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect();
+                    let mut table = TableBuilder::new(ui);
+                    for _ in &stat_names {
+                        table = table.column(TableColumn::auto());
+                    }
+                    table
+                        .striped(true)
+                        .header(18.0, |mut header| {
+                            for name in &stat_names {
+                                header.col(|ui| {
+                                    ui.label(name);
+                                });
+                            }
+                        })
+                        .body(|mut body| {
+                            for row_idx in 0..summary.stats.height() {
+                                body.row(18.0, |mut row| {
+                                    for col in summary.stats.get_columns() {
+                                        let val = col
+                                            .get(row_idx)
+                                            .map(|v| v.to_string())
+                                            .unwrap_or_default();
+                                        row.col(|ui| {
+                                            ui.label(val);
+                                        });
+                                    }
+                                });
+                            }
+                        });
+                }
+
                 #[cfg(feature = "plotting")]
                 {
                     use polars::prelude::DataType;


### PR DESCRIPTION
## Summary
- implement `summarize_dataframe` helper returning simple stats
- show DataFrame statistics in GUI preview panel
- document new statistics table in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68829cecb6e08332808232c8b579d15b