### PR TITLE
Improve partition directory reading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ plotting = ["dep:egui_plot"]
 
 [dev-dependencies]
 tempfile = "3"
+criterion = "0.5"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ common patterns:
   are collected into a `DataFrame`.
 * **`read_parquet_metadata`** – inspect low level metadata with the `parquet`
   crate without loading the entire file.
+* **`read_partitions`** – load all Parquet files from a directory pattern with a single
+  `scan_parquet` call.
 
 See [`src/parquet_examples.rs`](src/parquet_examples.rs) for implementation
 details and tests for each use case.
@@ -109,4 +111,9 @@ Example reading a file:
 ```
 cargo run -- read path/to/file.parquet
 ```
+
+## Benchmarks
+
+Running `cargo bench` builds a small benchmark comparing the old per-file
+collection approach against using `scan_parquet` over a directory pattern.
 

--- a/benches/scan_vs_collect.rs
+++ b/benches/scan_vs_collect.rs
@@ -1,0 +1,35 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use polars::prelude::*;
+use tempfile::tempdir;
+use polars_parquet_learning::parquet_examples;
+
+fn make_dir() -> std::path::PathBuf {
+    let dir = tempdir().unwrap();
+    for i in 0..5 {
+        let df = df!("id" => &[i as i64], "name" => &["a"]).unwrap();
+        let path = dir.path().join(format!("p{i}.parquet"));
+        parquet_examples::write_dataframe_to_parquet(&df, path.to_str().unwrap()).unwrap();
+    }
+    dir.into_path()
+}
+
+fn old_collect(dir: &str) -> DataFrame {
+    let mut dfs = Vec::new();
+    for e in std::fs::read_dir(dir).unwrap() {
+        let p = e.unwrap().path();
+        if p.extension().and_then(|e| e.to_str()) == Some("parquet") {
+            let lf = LazyFrame::scan_parquet(p.to_str().unwrap(), ScanArgsParquet::default()).unwrap();
+            dfs.push(lf.collect().unwrap());
+        }
+    }
+    polars::functions::concat_df(&dfs).unwrap()
+}
+
+fn bench(c: &mut Criterion) {
+    let dir = make_dir();
+    c.bench_function("old_collect", |b| b.iter(|| old_collect(dir.to_str().unwrap())));
+    c.bench_function("scan_parquet", |b| b.iter(|| parquet_examples::read_partitions(dir.to_str().unwrap()).unwrap()));
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -232,8 +232,7 @@ pub fn write_partitioned(df: &DataFrame, columns: &[&str], dir: &str) -> Result<
 /// Read all Parquet files in a directory and concatenate them into a single [`DataFrame`].
 pub fn read_partitions(dir: &str) -> Result<DataFrame> {
     let pattern = format!("{}/*.parquet", dir.trim_end_matches('/'));
-    let lf = LazyFrame::scan_parquet(&pattern, ScanArgsParquet::default())?;
-    Ok(lf.collect()?)
+    LazyFrame::scan_parquet(&pattern, ScanArgsParquet::default())?.collect()
 }
 
 /// Read all Parquet files in a directory using a single scan.


### PR DESCRIPTION
## Summary
- refactor `read_partitions` to call `scan_parquet` directly
- add a criterion benchmark showing the difference between scanning a directory and collecting files one by one
- document the new helper and benchmark instructions
- add benchmark dependency

## Testing
- `cargo bench --bench scan_vs_collect --no-run` *(fails: compilation hangs)*

------
https://chatgpt.com/codex/tasks/task_e_6882a779c8dc833280f7ef64c75dea8b