### PR TITLE
Accept mutable DataFrame for writers

### DIFF
--- a/benches/scan_vs_collect.rs
+++ b/benches/scan_vs_collect.rs
@@ -6,9 +6,9 @@ use polars_parquet_learning::parquet_examples;
 fn make_dir() -> std::path::PathBuf {
     let dir = tempdir().unwrap();
     for i in 0..5 {
-        let df = df!("id" => &[i as i64], "name" => &["a"]).unwrap();
+        let mut df = df!("id" => &[i as i64], "name" => &["a"]).unwrap();
         let path = dir.path().join(format!("p{i}.parquet"));
-        parquet_examples::write_dataframe_to_parquet(&df, path.to_str().unwrap()).unwrap();
+        parquet_examples::write_dataframe_to_parquet(&mut df, path.to_str().unwrap()).unwrap();
     }
     dir.into_path()
 }

--- a/src/background.rs
+++ b/src/background.rs
@@ -25,8 +25,8 @@ pub async fn read_directory(path: String) -> Result<JobResult> {
 }
 
 /// Asynchronously write a [`DataFrame`] to Parquet.
-pub async fn write_dataframe(df: DataFrame, path: String) -> Result<JobResult> {
-    task::spawn_blocking(move || parquet_examples::write_dataframe_to_parquet(&df, &path))
+pub async fn write_dataframe(mut df: DataFrame, path: String) -> Result<JobResult> {
+    task::spawn_blocking(move || parquet_examples::write_dataframe_to_parquet(&mut df, &path))
         .await??;
     Ok(JobResult::Unit)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,8 +103,8 @@ fn cmd_modify(file: &str) -> Result<()> {
 }
 
 fn cmd_write(input: &str, output: &str) -> Result<()> {
-    let df = parquet_examples::read_parquet_to_dataframe(input)?;
-    parquet_examples::write_dataframe_to_parquet(&df, output)?;
+    let mut df = parquet_examples::read_parquet_to_dataframe(input)?;
+    parquet_examples::write_dataframe_to_parquet(&mut df, output)?;
     println!("Wrote {output}");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -893,7 +893,8 @@ impl eframe::App for ParquetApp {
                     }
                     Operation::WriteCsv => {
                         if let Some(df) = &self.edit_df {
-                            match parquet_examples::write_dataframe_to_csv(df, &self.file_path) {
+                            let mut df = df.clone();
+                            match parquet_examples::write_dataframe_to_csv(&mut df, &self.file_path) {
                                 Ok(_) => self.status = format!("Wrote {}", self.file_path),
                                 Err(e) => self.status = format!("Write failed: {e}"),
                             }
@@ -901,7 +902,8 @@ impl eframe::App for ParquetApp {
                     }
                     Operation::WriteJson => {
                         if let Some(df) = &self.edit_df {
-                            match parquet_examples::write_dataframe_to_json(df, &self.file_path) {
+                            let mut df = df.clone();
+                            match parquet_examples::write_dataframe_to_json(&mut df, &self.file_path) {
                                 Ok(_) => self.status = format!("Wrote {}", self.file_path),
                                 Err(e) => self.status = format!("Write failed: {e}"),
                             }


### PR DESCRIPTION
## Summary
- update writer helper functions to accept `&mut DataFrame`
- adapt background tasks, CLI, GUI and benches for new API
- adjust tests for mutability

## Testing
- `cargo test --quiet --color never`

------
https://chatgpt.com/codex/tasks/task_e_6882aff81400833298af4dcf2edc6233