### PR TITLE
Support CSV and JSON input

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -24,6 +24,27 @@ pub async fn read_directory(path: String) -> Result<JobResult> {
     Ok(JobResult::DataFrame(df))
 }
 
+/// Asynchronously read a CSV file into a [`DataFrame`].
+pub async fn read_csv(path: String) -> Result<JobResult> {
+    let df = task::spawn_blocking(move || -> Result<DataFrame> {
+        Ok(CsvReadOptions::default()
+            .try_into_reader_with_file_path(Some(path.into()))?
+            .finish()?)
+    })
+    .await??;
+    Ok(JobResult::DataFrame(df))
+}
+
+/// Asynchronously read a JSON file into a [`DataFrame`].
+pub async fn read_json(path: String) -> Result<JobResult> {
+    let df = task::spawn_blocking(move || -> Result<DataFrame> {
+        let file = std::fs::File::open(&path)?;
+        Ok(JsonReader::new(file).finish()?)
+    })
+    .await??;
+    Ok(JobResult::DataFrame(df))
+}
+
 /// Asynchronously write a [`DataFrame`] to Parquet.
 pub async fn write_dataframe(mut df: DataFrame, path: String) -> Result<JobResult> {
     task::spawn_blocking(move || parquet_examples::write_dataframe_to_parquet(&mut df, &path))

--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -650,4 +650,19 @@ mod tests {
         assert!(json_path.exists());
         Ok(())
     }
+
+    #[test]
+    fn read_csv_file() -> Result<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join("data.csv");
+
+        let mut df = df!("id" => &[1i64, 2], "name" => &["a", "b"])?;
+        write_dataframe_to_csv(&mut df, path.to_str().unwrap())?;
+
+        let read = CsvReadOptions::default()
+            .try_into_reader_with_file_path(Some(path.to_path_buf()))?
+            .finish()?;
+        assert_eq!(read.shape(), df.shape());
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- allow selecting CSV or JSON files in the open dialog
- detect file extension in `start_read` and read CSV or JSON in the background
- update status messages based on file type
- add async helpers for reading CSV/JSON
- test CSV reading in `parquet_examples`

## Testing
- `cargo test --tests --release` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6882b87356f48332b5c31ab195339b62