### PR TITLE
Add XML to Parquet converter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,18 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "criterion",
  "eframe",
  "egui 0.32.0",
  "egui_extras",
  "egui_plot",
  "parquet",
  "polars",
+ "quick-xml 0.38.0",
  "rfd",
  "serde",
  "serde_derive",
+ "serde_json",
  "shlex",
  "tempfile",
  "tokio",
@@ -229,6 +232,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -934,6 +943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1018,33 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf 0.12.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1199,6 +1241,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2424,10 +2502,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3227,7 +3325,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.0",
@@ -3257,6 +3355,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -3494,6 +3598,34 @@ checksum = "3daf8e3d4b712abe1d690838f6e29fb76b76ea19589c4afa39ec30e12f62af71"
 dependencies = [
  "array-init-cursor",
  "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -5152,6 +5284,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,12 @@ rfd = "0.15"
 
 # Simplified error handling
 anyhow = "1.0"
+quick-xml = { version = "0.38", features = ["serialize"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 chrono = "0.4"
 shlex = "1.3"
 clap = { version = "4", features = ["derive"] }
+serde_json = "1.0"
 
 # Optional plotting support
 egui_plot = { version = "0.32", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod xml_to_parquet;

--- a/src/xml_to_parquet.rs
+++ b/src/xml_to_parquet.rs
@@ -1,0 +1,167 @@
+use anyhow::Result;
+use polars::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Field {
+    #[serde(rename = "@name")]
+    pub name: String,
+    #[serde(rename = "@value")]
+    pub value: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Template {
+    #[serde(rename = "@id")]
+    pub id: u32,
+    #[serde(rename = "@name")]
+    pub name: String,
+    #[serde(rename = "field", default)]
+    pub fields: Vec<Field>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Part {
+    #[serde(rename = "@content")]
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Message {
+    #[serde(rename = "@id")]
+    pub id: u32,
+    #[serde(rename = "@template_id")]
+    pub template_id: u32,
+    #[serde(rename = "part", default)]
+    pub parts: Vec<Part>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Repository {
+    #[serde(rename = "@id")]
+    pub id: u32,
+    #[serde(rename = "@path")]
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename = "root")]
+pub struct Root {
+    #[serde(rename = "template", default)]
+    pub templates: Vec<Template>,
+    #[serde(rename = "message", default)]
+    pub messages: Vec<Message>,
+    #[serde(rename = "repository", default)]
+    pub repositories: Vec<Repository>,
+}
+
+pub fn parse_xml(path: &str) -> Result<Root> {
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+    let root: Root = quick_xml::de::from_reader(reader)?;
+    Ok(root)
+}
+
+pub fn flatten_to_tables(root: &Root) -> Result<BTreeMap<&'static str, DataFrame>> {
+    let mut map = BTreeMap::new();
+
+    // templates table
+    let template_ids: Vec<u32> = root.templates.iter().map(|t| t.id).collect();
+    let template_names: Vec<String> = root.templates.iter().map(|t| t.name.clone()).collect();
+    let df_templates = df!("id" => template_ids, "name" => template_names)?;
+    map.insert("templates", df_templates);
+
+    // fields table
+    let mut f_tid = Vec::new();
+    let mut f_name = Vec::new();
+    let mut f_value = Vec::new();
+    for t in &root.templates {
+        for f in &t.fields {
+            f_tid.push(t.id);
+            f_name.push(f.name.clone());
+            f_value.push(f.value.clone());
+        }
+    }
+    if !f_tid.is_empty() {
+        let df_fields = df!("template_id" => f_tid, "name" => f_name, "value" => f_value)?;
+        map.insert("fields", df_fields);
+    }
+
+    // messages table
+    let msg_ids: Vec<u32> = root.messages.iter().map(|m| m.id).collect();
+    let msg_tids: Vec<u32> = root.messages.iter().map(|m| m.template_id).collect();
+    let df_messages = df!("id" => msg_ids, "template_id" => msg_tids)?;
+    map.insert("messages", df_messages);
+
+    // parts table
+    let mut p_mid = Vec::new();
+    let mut p_content = Vec::new();
+    for m in &root.messages {
+        for p in &m.parts {
+            p_mid.push(m.id);
+            p_content.push(p.content.clone());
+        }
+    }
+    if !p_mid.is_empty() {
+        let df_parts = df!("message_id" => p_mid, "content" => p_content)?;
+        map.insert("parts", df_parts);
+    }
+
+    // repositories table
+    let repo_ids: Vec<u32> = root.repositories.iter().map(|r| r.id).collect();
+    let repo_paths: Vec<String> = root.repositories.iter().map(|r| r.path.clone()).collect();
+    let df_repos = df!("id" => repo_ids, "path" => repo_paths)?;
+    map.insert("repositories", df_repos);
+
+    Ok(map)
+}
+
+#[derive(Serialize)]
+struct ForeignKey {
+    table: String,
+    column: String,
+    references: String,
+}
+
+#[derive(Serialize)]
+struct ExportSchema {
+    foreign_keys: Vec<ForeignKey>,
+}
+
+pub fn write_tables(tables: &BTreeMap<&str, DataFrame>, output_dir: &str) -> Result<()> {
+    use std::fs::File;
+    use std::path::Path;
+    std::fs::create_dir_all(output_dir)?;
+
+    let mut fks = Vec::new();
+    if tables.contains_key("fields") {
+        fks.push(ForeignKey {
+            table: "fields".into(),
+            column: "template_id".into(),
+            references: "templates.id".into(),
+        });
+    }
+    if tables.contains_key("parts") {
+        fks.push(ForeignKey {
+            table: "parts".into(),
+            column: "message_id".into(),
+            references: "messages.id".into(),
+        });
+    }
+
+    for (name, df) in tables {
+        let path = Path::new(output_dir).join(format!("{name}.parquet"));
+        let file = File::create(path)?;
+        let mut df = df.clone();
+        ParquetWriter::new(file).finish(&mut df)?;
+    }
+
+    if !fks.is_empty() {
+        let schema = ExportSchema { foreign_keys: fks };
+        let path = Path::new(output_dir).join("_schema.json");
+        let file = File::create(path)?;
+        serde_json::to_writer_pretty(file, &schema)?;
+    }
+    Ok(())
+}

--- a/tests/xml_to_parquet.rs
+++ b/tests/xml_to_parquet.rs
@@ -1,0 +1,40 @@
+use polars::prelude::*;
+use tempfile::tempdir;
+
+use Polars_Parquet_Learning::xml_to_parquet::{flatten_to_tables, parse_xml, write_tables};
+
+#[test]
+fn xml_round_trip() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let xml_path = dir.path().join("sample.xml");
+    std::fs::write(
+        &xml_path,
+        r#"<root>
+    <template id='1' name='temp'>
+        <field name='f1' value='v1'/>
+    </template>
+    <message id='10' template_id='1'>
+        <part content='a'/>
+        <part content='b'/>
+    </message>
+    <repository id='100' path='/tmp'/>
+</root>"#,
+    )?;
+
+    let root = parse_xml(xml_path.to_str().unwrap())?;
+    let tables = flatten_to_tables(&root)?;
+    assert!(tables.contains_key("templates"));
+    assert!(tables.contains_key("fields"));
+    assert!(tables.contains_key("messages"));
+    assert!(tables.contains_key("parts"));
+    assert!(tables.contains_key("repositories"));
+
+    let templates = &tables["templates"];
+    assert_eq!(templates.column("id")?.u32()?.get(0), Some(1));
+
+    let output_dir = dir.path().join("out");
+    write_tables(&tables, output_dir.to_str().unwrap())?;
+    assert!(output_dir.join("templates.parquet").exists());
+    assert!(output_dir.join("_schema.json").exists());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add quick-xml with serde support
- implement xml_to_parquet module
- expose library module
- provide unit test covering XML flattening and write

## Testing
- `cargo test --test xml_to_parquet -q`
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c1b21f808332a9cc9c46f4ce5203