### PR TITLE
Add XML CLI command

### DIFF
--- a/src/xml_to_parquet.rs
+++ b/src/xml_to_parquet.rs
@@ -129,7 +129,7 @@ struct ExportSchema {
     foreign_keys: Vec<ForeignKey>,
 }
 
-pub fn write_tables(tables: &BTreeMap<&str, DataFrame>, output_dir: &str) -> Result<()> {
+pub fn write_tables(tables: &BTreeMap<&str, DataFrame>, output_dir: &str, write_schema: bool) -> Result<()> {
     use std::fs::File;
     use std::path::Path;
     std::fs::create_dir_all(output_dir)?;
@@ -157,7 +157,7 @@ pub fn write_tables(tables: &BTreeMap<&str, DataFrame>, output_dir: &str) -> Res
         ParquetWriter::new(file).finish(&mut df)?;
     }
 
-    if !fks.is_empty() {
+    if write_schema && !fks.is_empty() {
         let schema = ExportSchema { foreign_keys: fks };
         let path = Path::new(output_dir).join("_schema.json");
         let file = File::create(path)?;
@@ -165,3 +165,10 @@ pub fn write_tables(tables: &BTreeMap<&str, DataFrame>, output_dir: &str) -> Res
     }
     Ok(())
 }
+
+pub fn xml_to_parquet(input: &str, output_dir: &str, write_schema: bool) -> Result<()> {
+    let root = parse_xml(input)?;
+    let tables = flatten_to_tables(&root)?;
+    write_tables(&tables, output_dir, write_schema)
+}
+

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -19,3 +19,28 @@ fn cli_read_runs() {
         .expect("run");
     assert!(status.success());
 }
+
+#[test]
+fn cli_xml_creates_files() {
+    let dir = tempdir().unwrap();
+    let xml_path = dir.path().join("data.xml");
+    std::fs::write(
+        &xml_path,
+        r#"<root><template id='1' name='t'/><message id='1' template_id='1'/></root>"#,
+    )
+    .unwrap();
+    let out_dir = dir.path().join("out");
+    let exe = env!("CARGO_BIN_EXE_Polars_Parquet_Learning");
+    let status = Command::new(exe)
+        .args([
+            "xml",
+            xml_path.to_str().unwrap(),
+            out_dir.to_str().unwrap(),
+            "--schema",
+        ])
+        .status()
+        .expect("run");
+    assert!(status.success());
+    assert!(out_dir.join("templates.parquet").exists());
+    assert!(out_dir.join("messages.parquet").exists());
+}

--- a/tests/xml_to_parquet.rs
+++ b/tests/xml_to_parquet.rs
@@ -33,7 +33,7 @@ fn xml_round_trip() -> anyhow::Result<()> {
     assert_eq!(templates.column("id")?.u32()?.get(0), Some(1));
 
     let output_dir = dir.path().join("out");
-    write_tables(&tables, output_dir.to_str().unwrap())?;
+    write_tables(&tables, output_dir.to_str().unwrap(), true)?;
     assert!(output_dir.join("templates.parquet").exists());
     assert!(output_dir.join("_schema.json").exists());
     Ok(())


### PR DESCRIPTION
## Summary
- add `xml` subcommand to CLI
- implement `XmlArgs` and `cmd_xml`
- support schema generation flag in xml utilities
- test XML conversion via CLI

## Testing
- `cargo test --quiet` *(fails: linker `cc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c848d99c8332844e9a48a94bfcad