### PR TITLE
Add XML fixture for integration tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::parquet_examples;
 use anyhow::Result;
-use crate::xml_to_parquet;
+use Polars_Parquet_Learning::xml_to_parquet;
 use clap::{Args, Parser, Subcommand};
 
 /// Top level command line arguments

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -23,18 +23,13 @@ fn cli_read_runs() {
 #[test]
 fn cli_xml_creates_files() {
     let dir = tempdir().unwrap();
-    let xml_path = dir.path().join("data.xml");
-    std::fs::write(
-        &xml_path,
-        r#"<root><template id='1' name='t'/><message id='1' template_id='1'/></root>"#,
-    )
-    .unwrap();
+    let xml_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/sample.xml");
     let out_dir = dir.path().join("out");
     let exe = env!("CARGO_BIN_EXE_Polars_Parquet_Learning");
     let status = Command::new(exe)
         .args([
             "xml",
-            xml_path.to_str().unwrap(),
+            xml_path,
             out_dir.to_str().unwrap(),
             "--schema",
         ])

--- a/tests/fixtures/sample.xml
+++ b/tests/fixtures/sample.xml
@@ -1,0 +1,11 @@
+<root>
+    <template id='1' name='temp'>
+        <field name='f1' value='v1'/>
+        <field name='f2' value='v2'/>
+    </template>
+    <message id='10' template_id='1'>
+        <part content='a'/>
+        <part content='b'/>
+    </message>
+    <repository id='100' path='/tmp'/>
+</root>

--- a/tests/xml_to_parquet.rs
+++ b/tests/xml_to_parquet.rs
@@ -6,22 +6,9 @@ use Polars_Parquet_Learning::xml_to_parquet::{flatten_to_tables, parse_xml, writ
 #[test]
 fn xml_round_trip() -> anyhow::Result<()> {
     let dir = tempdir()?;
-    let xml_path = dir.path().join("sample.xml");
-    std::fs::write(
-        &xml_path,
-        r#"<root>
-    <template id='1' name='temp'>
-        <field name='f1' value='v1'/>
-    </template>
-    <message id='10' template_id='1'>
-        <part content='a'/>
-        <part content='b'/>
-    </message>
-    <repository id='100' path='/tmp'/>
-</root>"#,
-    )?;
+    let xml_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/sample.xml");
 
-    let root = parse_xml(xml_path.to_str().unwrap())?;
+    let root = parse_xml(xml_path)?;
     let tables = flatten_to_tables(&root)?;
     assert!(tables.contains_key("templates"));
     assert!(tables.contains_key("fields"));


### PR DESCRIPTION
## Summary
- add `tests/fixtures/sample.xml`
- update integration tests to load this fixture
- fix CLI module import

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6882cedc509483328936c4023cbb8a9f