### PR TITLE
Add paginated Parquet reads

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -45,6 +45,14 @@ pub async fn read_json(path: String) -> Result<JobResult> {
     Ok(JobResult::DataFrame(df))
 }
 
+/// Asynchronously read a slice of rows from a Parquet file.
+pub async fn read_dataframe_slice(path: String, start: i64, len: usize) -> Result<JobResult> {
+    let df =
+        task::spawn_blocking(move || parquet_examples::read_parquet_slice(&path, start, len))
+            .await??;
+    Ok(JobResult::DataFrame(df))
+}
+
 /// Asynchronously write a [`DataFrame`] to Parquet.
 pub async fn write_dataframe(mut df: DataFrame, path: String) -> Result<JobResult> {
     task::spawn_blocking(move || parquet_examples::write_dataframe_to_parquet(&mut df, &path))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod xml_to_parquet;
 pub mod parquet_examples;
 pub mod cli;
+pub mod background;

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -1,0 +1,25 @@
+use polars::prelude::*;
+use tempfile::tempdir;
+use Polars_Parquet_Learning::{parquet_examples, background};
+
+#[test]
+fn paginate_multiple_pages() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("data.parquet");
+
+    let ids: Vec<i64> = (0..120).collect();
+    let names: Vec<String> = ids.iter().map(|i| format!("n{i}")).collect();
+    let mut df = df!("id" => ids, "name" => names)?;
+    parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let res1 = rt.block_on(background::read_dataframe_slice(file.to_str().unwrap().to_string(), 0, 50))?;
+    let res2 = rt.block_on(background::read_dataframe_slice(file.to_str().unwrap().to_string(), 50, 50))?;
+    if let background::JobResult::DataFrame(df1) = res1 {
+        assert_eq!(df1.height(), 50);
+    } else { panic!("unexpected result") }
+    if let background::JobResult::DataFrame(df2) = res2 {
+        assert_eq!(df2.height(), 50);
+    } else { panic!("unexpected result") }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support reading a slice of a Parquet file
- spawn async jobs to read Parquet slices
- track page state in `ParquetApp` and add controls to the preview
- add unit test and integration test for pagination

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6884f858e7e88332b6d460e6eb7b60cb