### PR TITLE
Add column filter support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # Polars DataFrame library with Parquet support
-polars = { version = "0.49.1", features = ["lazy", "parquet", "strings", "partition_by", "json"] }
+polars = { version = "0.49.1", features = ["lazy", "parquet", "strings", "partition_by", "json", "regex"] }
 
 # Low level Parquet crate (optional when using Polars)
 parquet = "55.2"

--- a/src/background.rs
+++ b/src/background.rs
@@ -59,3 +59,10 @@ pub async fn write_dataframe(mut df: DataFrame, path: String) -> Result<JobResul
         .await??;
     Ok(JobResult::Unit)
 }
+
+/// Asynchronously filter a Parquet file by multiple expressions.
+pub async fn filter_with_exprs(path: String, exprs: Vec<String>) -> Result<JobResult> {
+    let df = task::spawn_blocking(move || parquet_examples::filter_with_exprs(&path, &exprs))
+        .await??;
+    Ok(JobResult::DataFrame(df))
+}


### PR DESCRIPTION
## Summary
- add `FilterOp` enum and `ColumnFilter` struct
- store `column_filters` inside `ParquetApp`
- expose `apply_filters` to reload the file based on column filters
- add UI elements for per-column filtering
- support multiple filter expressions with `filter_with_exprs`

## Testing
- `cargo check`
- `cargo test` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_688502897bd08332a6f3ff4448290805