### PR TITLE
Enable paging on filtered results

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -97,6 +97,22 @@ pub async fn read_dataframe_slice(
     run_with_progress(tx, move || parquet_examples::read_parquet_slice(&path, start, len), JobResult::DataFrame).await;
 }
 
+/// Asynchronously filter a Parquet file and return a slice of rows.
+pub async fn read_filter_slice(
+    path: String,
+    exprs: Vec<String>,
+    start: i64,
+    len: usize,
+    tx: Sender<anyhow::Result<JobUpdate>>,
+) {
+    run_with_progress(
+        tx,
+        move || parquet_examples::filter_slice(&path, &exprs, start, len),
+        JobResult::DataFrame,
+    )
+    .await;
+}
+
 /// Asynchronously write a [`DataFrame`] to Parquet.
 pub async fn write_dataframe(mut df: DataFrame, path: String, tx: Sender<anyhow::Result<JobUpdate>>) {
     run_with_progress(

--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -505,6 +505,31 @@ pub fn filter_with_exprs(path: &str, exprs: &[String]) -> Result<DataFrame> {
     Ok(df)
 }
 
+/// Apply multiple expressions as filters and return a slice of rows.
+pub fn filter_slice(path: &str, exprs: &[String], start: i64, len: usize) -> Result<DataFrame> {
+    let mut lf = LazyFrame::scan_parquet(path, ScanArgsParquet::default())?;
+    let mut contains: Vec<(String, String)> = Vec::new();
+    for ex in exprs {
+        let parts: Vec<String> = shlex::Shlex::new(ex).collect();
+        if parts.len() == 3 && parts[1].eq_ignore_ascii_case("contains") {
+            let val = parts[2].trim_matches(&['"', '\''][..]).to_string();
+            contains.push((parts[0].clone(), val));
+        } else {
+            lf = lf.filter(parse_simple_expr(ex)?);
+        }
+    }
+    let mut df = lf.slice(start, len as u32).collect()?;
+    for (col, val) in contains {
+        let series = df
+            .column(&col)?
+            .as_series()
+            .ok_or_else(|| anyhow::anyhow!("missing series"))?;
+        let mask = series.str()?.contains_literal(&val)?;
+        df = df.filter(&mask)?;
+    }
+    Ok(df)
+}
+
 /// Retrieve low level metadata from a Parquet file using the `parquet` crate.
 ///
 /// Accessing the metadata can be useful for quickly inspecting files without

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -49,3 +49,110 @@ fn paginate_multiple_pages() -> anyhow::Result<()> {
     } else { panic!("unexpected result") }
     Ok(())
 }
+
+#[test]
+fn paginate_filtered_pages() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("data.parquet");
+
+    let ids: Vec<i64> = (0..100).collect();
+    let names: Vec<String> = ids
+        .iter()
+        .map(|i| if i % 2 == 0 { "yes".to_string() } else { "no".to_string() })
+        .collect();
+    let mut df = df!("id" => ids, "name" => names)?;
+    parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let exprs = vec!["name == \"yes\"".to_string()];
+
+    let (tx1, rx1) = std::sync::mpsc::channel();
+    rt.block_on(background::read_filter_slice(
+        file.to_str().unwrap().to_string(),
+        exprs.clone(),
+        0,
+        20,
+        tx1,
+    ));
+    let res1 = loop {
+        if let Ok(msg) = rx1.recv() {
+            if let Ok(background::JobUpdate::Done(res)) = msg {
+                break res;
+            }
+        }
+    };
+    let (tx2, rx2) = std::sync::mpsc::channel();
+    rt.block_on(background::read_filter_slice(
+        file.to_str().unwrap().to_string(),
+        exprs.clone(),
+        20,
+        20,
+        tx2,
+    ));
+    let res2 = loop {
+        if let Ok(msg) = rx2.recv() {
+            if let Ok(background::JobUpdate::Done(res)) = msg {
+                break res;
+            }
+        }
+    };
+    if let background::JobResult::DataFrame(df1) = res1 {
+        assert_eq!(df1.height(), 20);
+    } else { panic!("unexpected result") }
+    if let background::JobResult::DataFrame(df2) = res2 {
+        assert_eq!(df2.height(), 20);
+    } else { panic!("unexpected result") }
+    Ok(())
+}
+
+#[test]
+fn paginate_filtered_contains() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("data.parquet");
+
+    let ids: Vec<i64> = (0..120).collect();
+    let names: Vec<String> = ids.iter().map(|i| format!("n{i}")).collect();
+    let mut df = df!("id" => ids, "name" => names)?;
+    parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let exprs = vec!["name contains \"1\"".to_string()];
+
+    let (tx1, rx1) = std::sync::mpsc::channel();
+    rt.block_on(background::read_filter_slice(
+        file.to_str().unwrap().to_string(),
+        exprs.clone(),
+        0,
+        30,
+        tx1,
+    ));
+    let res1 = loop {
+        if let Ok(msg) = rx1.recv() {
+            if let Ok(background::JobUpdate::Done(res)) = msg {
+                break res;
+            }
+        }
+    };
+    let (tx2, rx2) = std::sync::mpsc::channel();
+    rt.block_on(background::read_filter_slice(
+        file.to_str().unwrap().to_string(),
+        exprs.clone(),
+        30,
+        30,
+        tx2,
+    ));
+    let res2 = loop {
+        if let Ok(msg) = rx2.recv() {
+            if let Ok(background::JobUpdate::Done(res)) = msg {
+                break res;
+            }
+        }
+    };
+    if let background::JobResult::DataFrame(df1) = res1 {
+        assert_eq!(df1.height(), 30);
+    } else { panic!("unexpected result") }
+    if let background::JobResult::DataFrame(df2) = res2 {
+        assert_eq!(df2.height(), 30);
+    } else { panic!("unexpected result") }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `filter_slice` helper to return filtered slices
- expose `read_filter_slice` in background tasks
- apply filters using new lazy reader
- keep pagination working after filtering
- test filtered pagination

## Testing
- `cargo test --quiet` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68851db886b48332bfbdc77d7a5c01df