### PR TITLE
Add configurable page size and update tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -568,6 +568,15 @@ impl eframe::App for ParquetApp {
                     });
                 }
                 ui.horizontal(|ui| {
+                    ui.label("Page size:");
+                    if ui
+                        .add(egui::DragValue::new(&mut self.page_size).clamp_range(1..=1000))
+                        .changed()
+                    {
+                        self.load_page();
+                    }
+                });
+                ui.horizontal(|ui| {
                     ui.label("Rows to display:");
                     ui.add(egui::DragValue::new(&mut self.display_rows).clamp_range(1..=1000));
                     if ui.button("Toggle schema").clicked() {

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -1,6 +1,6 @@
+use Polars_Parquet_Learning::{background, parquet_examples};
 use polars::prelude::*;
 use tempfile::tempdir;
-use Polars_Parquet_Learning::{parquet_examples, background};
 
 #[test]
 fn paginate_multiple_pages() -> anyhow::Result<()> {
@@ -17,7 +17,7 @@ fn paginate_multiple_pages() -> anyhow::Result<()> {
     rt.block_on(background::read_dataframe_slice(
         file.to_str().unwrap().to_string(),
         0,
-        50,
+        40,
         tx1,
     ));
     let res1 = loop {
@@ -30,8 +30,8 @@ fn paginate_multiple_pages() -> anyhow::Result<()> {
     let (tx2, rx2) = std::sync::mpsc::channel();
     rt.block_on(background::read_dataframe_slice(
         file.to_str().unwrap().to_string(),
-        50,
-        50,
+        40,
+        40,
         tx2,
     ));
     let res2 = loop {
@@ -42,11 +42,15 @@ fn paginate_multiple_pages() -> anyhow::Result<()> {
         }
     };
     if let background::JobResult::DataFrame(df1) = res1 {
-        assert_eq!(df1.height(), 50);
-    } else { panic!("unexpected result") }
+        assert_eq!(df1.height(), 40);
+    } else {
+        panic!("unexpected result")
+    }
     if let background::JobResult::DataFrame(df2) = res2 {
-        assert_eq!(df2.height(), 50);
-    } else { panic!("unexpected result") }
+        assert_eq!(df2.height(), 40);
+    } else {
+        panic!("unexpected result")
+    }
     Ok(())
 }
 
@@ -58,7 +62,13 @@ fn paginate_filtered_pages() -> anyhow::Result<()> {
     let ids: Vec<i64> = (0..100).collect();
     let names: Vec<String> = ids
         .iter()
-        .map(|i| if i % 2 == 0 { "yes".to_string() } else { "no".to_string() })
+        .map(|i| {
+            if i % 2 == 0 {
+                "yes".to_string()
+            } else {
+                "no".to_string()
+            }
+        })
         .collect();
     let mut df = df!("id" => ids, "name" => names)?;
     parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
@@ -71,7 +81,7 @@ fn paginate_filtered_pages() -> anyhow::Result<()> {
         file.to_str().unwrap().to_string(),
         exprs.clone(),
         0,
-        20,
+        15,
         tx1,
     ));
     let res1 = loop {
@@ -85,8 +95,8 @@ fn paginate_filtered_pages() -> anyhow::Result<()> {
     rt.block_on(background::read_filter_slice(
         file.to_str().unwrap().to_string(),
         exprs.clone(),
-        20,
-        20,
+        15,
+        15,
         tx2,
     ));
     let res2 = loop {
@@ -97,11 +107,15 @@ fn paginate_filtered_pages() -> anyhow::Result<()> {
         }
     };
     if let background::JobResult::DataFrame(df1) = res1 {
-        assert_eq!(df1.height(), 20);
-    } else { panic!("unexpected result") }
+        assert_eq!(df1.height(), 15);
+    } else {
+        panic!("unexpected result")
+    }
     if let background::JobResult::DataFrame(df2) = res2 {
-        assert_eq!(df2.height(), 20);
-    } else { panic!("unexpected result") }
+        assert_eq!(df2.height(), 15);
+    } else {
+        panic!("unexpected result")
+    }
     Ok(())
 }
 
@@ -123,7 +137,7 @@ fn paginate_filtered_contains() -> anyhow::Result<()> {
         file.to_str().unwrap().to_string(),
         exprs.clone(),
         0,
-        30,
+        25,
         tx1,
     ));
     let res1 = loop {
@@ -137,8 +151,8 @@ fn paginate_filtered_contains() -> anyhow::Result<()> {
     rt.block_on(background::read_filter_slice(
         file.to_str().unwrap().to_string(),
         exprs.clone(),
-        30,
-        30,
+        25,
+        25,
         tx2,
     ));
     let res2 = loop {
@@ -149,10 +163,14 @@ fn paginate_filtered_contains() -> anyhow::Result<()> {
         }
     };
     if let background::JobResult::DataFrame(df1) = res1 {
-        assert_eq!(df1.height(), 30);
-    } else { panic!("unexpected result") }
+        assert_eq!(df1.height(), 25);
+    } else {
+        panic!("unexpected result")
+    }
     if let background::JobResult::DataFrame(df2) = res2 {
-        assert_eq!(df2.height(), 30);
-    } else { panic!("unexpected result") }
+        assert_eq!(df2.height(), 25);
+    } else {
+        panic!("unexpected result")
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- enable configuring page size in the preview panel
- reload data whenever page size changes
- update pagination tests to use differing page sizes

## Testing
- `cargo test --quiet pagination` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6885356edadc8332954d09136be74c71