### PR TITLE
Add histogram controls and axis ranges

### DIFF
--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -1,0 +1,10 @@
+use Polars_Parquet_Learning::parquet_examples::compute_histogram;
+
+#[test]
+fn histogram_respects_bins() {
+    let values = vec![0.0, 1.0, 2.0, 3.0, 4.0];
+    let (counts, _min, _step) = compute_histogram(&values, 5, None);
+    assert_eq!(counts.len(), 5);
+    let total: f64 = counts.iter().sum();
+    assert_eq!(total as usize, values.len());
+}

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -168,7 +168,7 @@ fn paginate_filtered_contains() -> anyhow::Result<()> {
         panic!("unexpected result")
     }
     if let background::JobResult::DataFrame(df2) = res2 {
-        assert_eq!(df2.height(), 25);
+        assert_eq!(df2.height(), 14);
     } else {
         panic!("unexpected result")
     }


### PR DESCRIPTION
## Summary
- add histogram bin count and axis range controls to `ParquetApp`
- compute histograms with a new `compute_histogram` helper
- update plot UI to use adjustable bins and ranges
- fix filtering slice order and pagination test
- add tests for histogram bin count

## Testing
- `cargo test --lib --quiet`
- `cargo test --test cli --quiet`
- `cargo test --test column_ops --quiet`
- `cargo test --test filter_count --quiet`
- `cargo test --test xml_to_parquet --quiet`
- `cargo test --test histogram --quiet`
- `cargo test --test pagination --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688553956a4c833286cad9cce4e86737