### PR TITLE
Add DataFrame memory usage summary

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -621,11 +621,13 @@ impl eframe::App for ParquetApp {
             egui::SidePanel::right("preview_panel").show(ctx, |ui| {
                 ui.heading("Preview");
                 let end = (self.page_start + df.height()).min(self.total_rows);
+                let approx = df.estimated_size();
                 ui.label(format!(
-                    "Rows {}-{} of {}",
+                    "Rows {}-{} of {} (~{} bytes)",
                     self.page_start + 1,
                     end,
-                    self.total_rows
+                    self.total_rows,
+                    approx
                 ));
                 ui.horizontal(|ui| {
                     ui.label("Search:");
@@ -784,6 +786,7 @@ impl eframe::App for ParquetApp {
                     ui.label("Statistics");
                     ui.label(format!("Rows: {}", summary.rows));
                     ui.label(format!("Columns: {}", summary.columns));
+                    ui.label(format!("Approx size: {} bytes", summary.approx_bytes));
 
                     let stat_names: Vec<String> = summary
                         .stats
@@ -1468,6 +1471,11 @@ impl eframe::App for ParquetApp {
                 if let Some(meta) = &self.metadata {
                     ui.label("Metadata");
                     egui::Grid::new("meta_grid").striped(true).show(ui, |ui| {
+                        ui.label(format!(
+                            "File size: {} bytes",
+                            meta.file_metadata().total_byte_size()
+                        ));
+                        ui.end_row();
                         ui.label(format!("Row groups: {}", meta.num_row_groups()));
                         ui.end_row();
                         for (i, rg) in meta.row_groups().iter().enumerate() {

--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -18,6 +18,8 @@ pub struct DataFrameSummary {
     pub rows: usize,
     /// Number of columns in the frame.
     pub columns: usize,
+    /// Approximate memory usage of the frame in bytes.
+    pub approx_bytes: usize,
     /// Simple statistics for each column.
     pub stats: DataFrame,
 }
@@ -274,6 +276,7 @@ pub fn summarize_dataframe(df: &DataFrame) -> Result<DataFrameSummary> {
     Ok(DataFrameSummary {
         rows: df.height(),
         columns: df.width(),
+        approx_bytes: df.estimated_size(),
         stats,
     })
 }

--- a/tests/summary.rs
+++ b/tests/summary.rs
@@ -1,0 +1,16 @@
+use polars::prelude::*;
+use Polars_Parquet_Learning::parquet_examples::summarize_dataframe;
+
+#[test]
+fn summary_reports_size() -> anyhow::Result<()> {
+    let df = df!("id" => &[1i64, 2, 3], "name" => &["a", "b", "c"])?;
+    let summary = summarize_dataframe(&df)?;
+    let est = df.estimated_size();
+    let diff = if summary.approx_bytes > est {
+        summary.approx_bytes - est
+    } else {
+        est - summary.approx_bytes
+    };
+    assert!(diff <= est / 10);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- estimate and display DataFrame memory usage
- show file size in metadata panel
- expose approx_bytes via summarize_dataframe
- test DataFrame size reporting

## Testing
- `cargo test summary_reports_size -- --nocapture` *(fails: linking with `cc` failed)*

 