### PR TITLE
Fix histogram for constant values

### DIFF
--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -427,7 +427,11 @@ pub fn read_parquet_slice(path: &str, start: i64, len: usize) -> Result<DataFram
 /// Compute histogram counts for a slice of values.
 ///
 /// Returns the bin counts along with the minimum value and bin step.
-pub fn compute_histogram(values: &[f64], bins: usize, range: Option<(f64, f64)>) -> (Vec<f64>, f64, f64) {
+pub fn compute_histogram(
+    values: &[f64],
+    bins: usize,
+    range: Option<(f64, f64)>,
+) -> (Vec<f64>, f64, f64) {
     if bins == 0 {
         return (Vec::new(), 0.0, 0.0);
     }
@@ -445,7 +449,9 @@ pub fn compute_histogram(values: &[f64], bins: usize, range: Option<(f64, f64)>)
     };
     let step = (max - min) / bins as f64;
     let mut counts = vec![0f64; bins];
-    if step != 0.0 {
+    if step == 0.0 {
+        counts[0] = values.len() as f64;
+    } else {
         for &v in values {
             let mut idx = ((v - min) / step).floor() as isize;
             if idx < 0 {

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -8,3 +8,12 @@ fn histogram_respects_bins() {
     let total: f64 = counts.iter().sum();
     assert_eq!(total as usize, values.len());
 }
+
+#[test]
+fn histogram_constant_values() {
+    let values = vec![1.0, 1.0, 1.0, 1.0];
+    let (counts, _min, _step) = compute_histogram(&values, 3, None);
+    assert_eq!(counts.len(), 3);
+    assert_eq!(counts[0] as usize, values.len());
+    assert!(counts[1..].iter().all(|&c| c == 0.0));
+}


### PR DESCRIPTION
## Summary
- handle equal min/max in `compute_histogram`
- test histogram with constant values

## Testing
- `cargo test --no-run` *(fails: collect2 killed)*

------
https://chatgpt.com/codex/tasks/task_e_6885648a283c83328dfbb1835a2b481f