### PR TITLE
Add XML round trip example functions and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,10 @@ The GUI offers the same functionality via the **XML** mode. Select an input
 file in the **File** field, choose an output directory in **Save** and decide
 whether to write a `_schema.json` using the checkbox before clicking **Run**.
 
+Additional helper functions in [`src/xml_examples.rs`](src/xml_examples.rs)
+demonstrate a full round trip using the bundled
+[`sample.xml`](tests/fixtures/sample.xml). They parse the XML into a `Root`,
+convert it to `DataFrame`s, write them as Parquet files, read the tables back
+into a `Root` and finally serialize it to an XML string again. See
+[`tests/xml_round_trip.rs`](tests/xml_round_trip.rs) for usage.
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-pub mod xml_to_parquet;
-pub mod parquet_examples;
-pub mod cli;
 pub mod background;
+pub mod cli;
+pub mod parquet_examples;
 pub mod search;
+pub mod xml_examples;
+pub mod xml_to_parquet;

--- a/src/xml_examples.rs
+++ b/src/xml_examples.rs
@@ -1,0 +1,125 @@
+use crate::{parquet_examples, xml_to_parquet};
+use anyhow::Result;
+use polars::prelude::*;
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+
+/// Parse the bundled `sample.xml` file into a [`Root`] struct.
+pub fn parse_sample_xml() -> Result<xml_to_parquet::Root> {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/sample.xml");
+    xml_to_parquet::parse_xml(path)
+}
+
+/// Convert the provided [`Root`] into normalised [`DataFrame`] tables.
+pub fn root_to_tables(root: &xml_to_parquet::Root) -> Result<BTreeMap<&'static str, DataFrame>> {
+    xml_to_parquet::flatten_to_tables(root)
+}
+
+/// Write the tables returned by [`root_to_tables`] to `output_dir`.
+///
+/// The files are named `<table>.parquet` and no schema file is emitted.
+pub fn write_tables_to_parquet(tables: &BTreeMap<&str, DataFrame>, output_dir: &str) -> Result<()> {
+    xml_to_parquet::write_tables(tables, output_dir, false)
+}
+
+/// Read previously written Parquet tables and rebuild the [`Root`] structure.
+pub fn read_parquet_to_root(dir: &str) -> Result<xml_to_parquet::Root> {
+    let p = Path::new(dir);
+    let templates =
+        parquet_examples::read_parquet_to_dataframe(p.join("templates.parquet").to_str().unwrap())?;
+    let messages =
+        parquet_examples::read_parquet_to_dataframe(p.join("messages.parquet").to_str().unwrap())?;
+    let repositories = parquet_examples::read_parquet_to_dataframe(
+        p.join("repositories.parquet").to_str().unwrap(),
+    )?;
+
+    let fields_path = p.join("fields.parquet");
+    let fields = if fields_path.exists() {
+        Some(parquet_examples::read_parquet_to_dataframe(
+            fields_path.to_str().unwrap(),
+        )?)
+    } else {
+        None
+    };
+    let parts_path = p.join("parts.parquet");
+    let parts = if parts_path.exists() {
+        Some(parquet_examples::read_parquet_to_dataframe(
+            parts_path.to_str().unwrap(),
+        )?)
+    } else {
+        None
+    };
+
+    // Build maps of foreign key -> rows
+    let mut field_map: HashMap<u32, Vec<xml_to_parquet::Field>> = HashMap::new();
+    if let Some(df) = &fields {
+        let tids = df.column("template_id")?.u32()?;
+        let names = df.column("name")?.str()?;
+        let values = df.column("value")?.str()?;
+        for i in 0..df.height() {
+            let tid = tids.get(i).unwrap();
+            let f = xml_to_parquet::Field {
+                name: names.get(i).unwrap().to_string(),
+                value: values.get(i).unwrap().to_string(),
+            };
+            field_map.entry(tid).or_default().push(f);
+        }
+    }
+
+    let mut templates_vec = Vec::new();
+    let ids = templates.column("id")?.u32()?;
+    let names = templates.column("name")?.str()?;
+    for i in 0..templates.height() {
+        let id = ids.get(i).unwrap();
+        let name = names.get(i).unwrap().to_string();
+        let fields = field_map.remove(&id).unwrap_or_default();
+        templates_vec.push(xml_to_parquet::Template { id, name, fields });
+    }
+
+    let mut part_map: HashMap<u32, Vec<xml_to_parquet::Part>> = HashMap::new();
+    if let Some(df) = &parts {
+        let mids = df.column("message_id")?.u32()?;
+        let contents = df.column("content")?.str()?;
+        for i in 0..df.height() {
+            let mid = mids.get(i).unwrap();
+            let p = xml_to_parquet::Part {
+                content: contents.get(i).unwrap().to_string(),
+            };
+            part_map.entry(mid).or_default().push(p);
+        }
+    }
+
+    let mut messages_vec = Vec::new();
+    let msg_ids = messages.column("id")?.u32()?;
+    let msg_tids = messages.column("template_id")?.u32()?;
+    for i in 0..messages.height() {
+        let id = msg_ids.get(i).unwrap();
+        let template_id = msg_tids.get(i).unwrap();
+        let parts = part_map.remove(&id).unwrap_or_default();
+        messages_vec.push(xml_to_parquet::Message {
+            id,
+            template_id,
+            parts,
+        });
+    }
+
+    let mut repos_vec = Vec::new();
+    let repo_ids = repositories.column("id")?.u32()?;
+    let repo_paths = repositories.column("path")?.str()?;
+    for i in 0..repositories.height() {
+        let id = repo_ids.get(i).unwrap();
+        let path = repo_paths.get(i).unwrap().to_string();
+        repos_vec.push(xml_to_parquet::Repository { id, path });
+    }
+
+    Ok(xml_to_parquet::Root {
+        templates: templates_vec,
+        messages: messages_vec,
+        repositories: repos_vec,
+    })
+}
+
+/// Serialize the [`Root`] back into an XML string.
+pub fn root_to_xml(root: &xml_to_parquet::Root) -> Result<String> {
+    Ok(quick_xml::se::to_string(root)?)
+}

--- a/src/xml_to_parquet.rs
+++ b/src/xml_to_parquet.rs
@@ -3,7 +3,7 @@ use polars::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Field {
     #[serde(rename = "@name")]
     pub name: String,
@@ -11,7 +11,7 @@ pub struct Field {
     pub value: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Template {
     #[serde(rename = "@id")]
     pub id: u32,
@@ -21,13 +21,13 @@ pub struct Template {
     pub fields: Vec<Field>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Part {
     #[serde(rename = "@content")]
     pub content: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Message {
     #[serde(rename = "@id")]
     pub id: u32,
@@ -37,7 +37,7 @@ pub struct Message {
     pub parts: Vec<Part>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Repository {
     #[serde(rename = "@id")]
     pub id: u32,
@@ -45,7 +45,7 @@ pub struct Repository {
     pub path: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename = "root")]
 pub struct Root {
     #[serde(rename = "template", default)]
@@ -129,7 +129,11 @@ struct ExportSchema {
     foreign_keys: Vec<ForeignKey>,
 }
 
-pub fn write_tables(tables: &BTreeMap<&str, DataFrame>, output_dir: &str, write_schema: bool) -> Result<()> {
+pub fn write_tables(
+    tables: &BTreeMap<&str, DataFrame>,
+    output_dir: &str,
+    write_schema: bool,
+) -> Result<()> {
     use std::fs::File;
     use std::path::Path;
     std::fs::create_dir_all(output_dir)?;
@@ -171,4 +175,3 @@ pub fn xml_to_parquet(input: &str, output_dir: &str, write_schema: bool) -> Resu
     let tables = flatten_to_tables(&root)?;
     write_tables(&tables, output_dir, write_schema)
 }
-

--- a/tests/xml_round_trip.rs
+++ b/tests/xml_round_trip.rs
@@ -1,0 +1,22 @@
+use tempfile::tempdir;
+
+use Polars_Parquet_Learning::{xml_examples, xml_to_parquet};
+
+#[test]
+fn xml_examples_round_trip() -> anyhow::Result<()> {
+    let root = xml_examples::parse_sample_xml()?;
+    let tables = xml_examples::root_to_tables(&root)?;
+    let dir = tempdir()?;
+    xml_examples::write_tables_to_parquet(&tables, dir.path().to_str().unwrap())?;
+
+    let round = xml_examples::read_parquet_to_root(dir.path().to_str().unwrap())?;
+    assert_eq!(round, root);
+
+    let round_tables = xml_examples::root_to_tables(&round)?;
+    assert_eq!(tables.keys().count(), round_tables.keys().count());
+
+    let xml = xml_examples::root_to_xml(&round)?;
+    let root2: xml_to_parquet::Root = quick_xml::de::from_str(&xml)?;
+    assert_eq!(root2.templates.len(), root.templates.len());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- provide xml_examples module showcasing an XML-to-Parquet round trip
- derive `Serialize` and `PartialEq` on XML structs
- test round trip using the bundled sample XML
- document usage of the new examples

## Testing
- `cargo test` *(fails: collect2: fatal error: ld terminated with signal 9)*

------
https://chatgpt.com/codex/tasks/task_e_68857a86e3e8833281bb7bf68af2a4ee