### PR TITLE
Add dynamic XML parsing helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "Polars_Parquet_Learning"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 # Polars DataFrame library with Parquet support
 polars = { version = "0.49.1", features = ["lazy", "parquet", "strings", "partition_by", "json", "regex"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod background;
 pub mod cli;
 pub mod parquet_examples;
 pub mod search;
+pub mod xml_dynamic;
 pub mod xml_examples;
 pub mod xml_to_parquet;

--- a/src/xml_dynamic.rs
+++ b/src/xml_dynamic.rs
@@ -1,0 +1,23 @@
+use crate::xml_to_parquet::{self, Root};
+use anyhow::Result;
+use polars::prelude::*;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Parse any XML file supported by [`xml_to_parquet`] and return a dynamic
+/// [`serde_json::Value`] representation.
+pub fn parse_any_xml(path: &str) -> Result<Value> {
+    let root: Root = xml_to_parquet::parse_xml(path)?;
+    Ok(serde_json::to_value(root)?)
+}
+
+/// Convert a [`serde_json::Value`] produced by [`parse_any_xml`] into
+/// normalized [`DataFrame`] tables.
+pub fn value_to_tables(value: &Value) -> Result<BTreeMap<String, DataFrame>> {
+    let root: Root = serde_json::from_value(value.clone())?;
+    let tables = xml_to_parquet::flatten_to_tables(&root)?;
+    Ok(tables
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect())
+}


### PR DESCRIPTION
## Summary
- expose library module for dynamic XML use
- add `xml_dynamic.rs` for converting arbitrary XML

## Testing
- `cargo test --quiet` *(fails: ld terminated with signal 9)*

------
https://chatgpt.com/codex/tasks/task_e_68857ebc4fc88332b9f8aa7563f1eba2