### PR TITLE
Improve error handling in XML examples

### DIFF
--- a/src/xml_examples.rs
+++ b/src/xml_examples.rs
@@ -25,18 +25,28 @@ pub fn write_tables_to_parquet(tables: &BTreeMap<&str, DataFrame>, output_dir: &
 /// Read previously written Parquet tables and rebuild the [`Root`] structure.
 pub fn read_parquet_to_root(dir: &str) -> Result<xml_to_parquet::Root> {
     let p = Path::new(dir);
-    let templates =
-        parquet_examples::read_parquet_to_dataframe(p.join("templates.parquet").to_str().unwrap())?;
-    let messages =
-        parquet_examples::read_parquet_to_dataframe(p.join("messages.parquet").to_str().unwrap())?;
+    let templates = parquet_examples::read_parquet_to_dataframe(
+        p.join("templates.parquet")
+            .to_str()
+            .ok_or_else(|| anyhow!("missing templates path"))?,
+    )?;
+    let messages = parquet_examples::read_parquet_to_dataframe(
+        p.join("messages.parquet")
+            .to_str()
+            .ok_or_else(|| anyhow!("missing messages path"))?,
+    )?;
     let repositories = parquet_examples::read_parquet_to_dataframe(
-        p.join("repositories.parquet").to_str().unwrap(),
+        p.join("repositories.parquet")
+            .to_str()
+            .ok_or_else(|| anyhow!("missing repositories path"))?,
     )?;
 
     let fields_path = p.join("fields.parquet");
     let fields = if fields_path.exists() {
         Some(parquet_examples::read_parquet_to_dataframe(
-            fields_path.to_str().unwrap(),
+            fields_path
+                .to_str()
+                .ok_or_else(|| anyhow!("missing fields path"))?,
         )?)
     } else {
         None
@@ -44,7 +54,9 @@ pub fn read_parquet_to_root(dir: &str) -> Result<xml_to_parquet::Root> {
     let parts_path = p.join("parts.parquet");
     let parts = if parts_path.exists() {
         Some(parquet_examples::read_parquet_to_dataframe(
-            parts_path.to_str().unwrap(),
+            parts_path
+                .to_str()
+                .ok_or_else(|| anyhow!("missing parts path"))?,
         )?)
     } else {
         None

--- a/tests/read_parquet_error.rs
+++ b/tests/read_parquet_error.rs
@@ -1,0 +1,23 @@
+use polars::prelude::*;
+use tempfile::tempdir;
+use Polars_Parquet_Learning::xml_examples;
+
+#[test]
+fn read_parquet_with_nulls_returns_error() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    // create minimal tables with a null value in templates.name
+    let mut templates = df!("id" => &[1u32], "name" => &[Option::<&str>::None])?;
+    let mut messages = df!("id" => &[1u32], "template_id" => &[1u32])?;
+    let mut repos = df!("id" => &[1u32], "path" => &["/tmp"])?;
+
+    ParquetWriter::new(std::fs::File::create(dir.path().join("templates.parquet"))?)
+        .finish(&mut templates)?;
+    ParquetWriter::new(std::fs::File::create(dir.path().join("messages.parquet"))?)
+        .finish(&mut messages)?;
+    ParquetWriter::new(std::fs::File::create(dir.path().join("repositories.parquet"))?)
+        .finish(&mut repos)?;
+
+    let result = xml_examples::read_parquet_to_root(dir.path().to_str().unwrap());
+    assert!(result.is_err());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- use error propagation when reading parquet tables instead of unwrap
- add failing read-parquet test for nulls

## Testing
- `cargo test --no-run` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_688615da55988332b143913eb387dd94