### PR TITLE
Add case-insensitive search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1,14 +1,20 @@
 /// Search utilities for table data.
 
 /// Return all cell coordinates containing `query`.
-pub fn find_matches(rows: &[Vec<String>], query: &str) -> Vec<(usize, usize)> {
+pub fn find_matches(rows: &[Vec<String>], query: &str, ignore_case: bool) -> Vec<(usize, usize)> {
     if query.is_empty() {
         return Vec::new();
     }
+    let query_cmp = if ignore_case {
+        query.to_lowercase()
+    } else {
+        query.to_string()
+    };
     let mut out = Vec::new();
     for (r, row) in rows.iter().enumerate() {
         for (c, cell) in row.iter().enumerate() {
-            if cell.contains(query) {
+            let hay = if ignore_case { cell.to_lowercase() } else { cell.clone() };
+            if hay.contains(&query_cmp) {
                 out.push((r, c));
             }
         }

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -6,7 +6,7 @@ fn navigate_matches_cycles() {
         vec!["apple".to_string(), "banana".to_string()],
         vec!["carrot".to_string(), "apple".to_string()],
     ];
-    let matches = find_matches(&rows, "apple");
+    let matches = find_matches(&rows, "apple", false);
     assert_eq!(matches, vec![(0, 0), (1, 1)]);
     let mut idx = 0;
     idx = next_index(idx, &matches);
@@ -22,8 +22,20 @@ fn navigate_matches_cycles() {
 #[test]
 fn navigation_with_no_matches() {
     let rows = vec![vec!["a".to_string()]];
-    let matches = find_matches(&rows, "z");
+    let matches = find_matches(&rows, "z", false);
     assert!(matches.is_empty());
     assert_eq!(next_index(0, &matches), 0);
     assert_eq!(prev_index(0, &matches), 0);
+}
+
+#[test]
+fn case_insensitive_search() {
+    let rows = vec![
+        vec!["Apple".to_string(), "banana".to_string()],
+        vec!["carrot".to_string(), "APPLE".to_string()],
+    ];
+    let matches = find_matches(&rows, "apple", true);
+    assert_eq!(matches, vec![(0, 0), (1, 1)]);
+    let no_matches = find_matches(&rows, "apple", false);
+    assert!(no_matches.is_empty());
 }


### PR DESCRIPTION
## Summary
- expand `find_matches` to support case-insensitive search
- add a flag and checkbox for case-insensitive search in GUI
- update search matching logic and tests

## Testing
- `cargo test --test search -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_688615edfe8c8332842fa51442cdeef5