### PR TITLE
Add correlation matrix computation

### DIFF
--- a/tests/correlation.rs
+++ b/tests/correlation.rs
@@ -1,0 +1,18 @@
+use polars::prelude::*;
+use Polars_Parquet_Learning::parquet_examples::correlation_matrix;
+
+#[test]
+fn matrix_basic() -> anyhow::Result<()> {
+    let df = df!(
+        "a" => &[1.0f64, 2.0, 3.0],
+        "b" => &[1.0f64, 2.0, 3.0],
+        "c" => &[3.0f64, 2.0, 1.0]
+    )?;
+    let corr = correlation_matrix(&df, &["a", "b", "c"])?;
+    assert_eq!(corr.shape(), (3, 4));
+    let labels: Vec<&str> = corr.column("column")?.str()?.into_no_null_iter().collect();
+    assert_eq!(labels, vec!["a", "b", "c"]);
+    let col_b: Vec<f64> = corr.column("b")?.f64()?.into_no_null_iter().collect();
+    assert_eq!(col_b, vec![1.0, 1.0, -1.0]);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `correlation_matrix` helper to generate a Pearson correlation matrix for numeric columns
- implement a helper `pearson_corr_slice`
- test correlation matrix on a small dataset

## Testing
- `cargo test matrix_basic --release -- --test-threads 1` *(fails: ld terminated with signal 9)*

------
https://chatgpt.com/codex/tasks/task_e_688619d428c08332956e00ef935b5606