### PR TITLE
Add correlation matrix operation

### DIFF
--- a/tests/correlation.rs
+++ b/tests/correlation.rs
@@ -1,5 +1,5 @@
-use polars::prelude::*;
 use Polars_Parquet_Learning::parquet_examples::correlation_matrix;
+use polars::prelude::*;
 
 #[test]
 fn matrix_basic() -> anyhow::Result<()> {
@@ -14,5 +14,30 @@ fn matrix_basic() -> anyhow::Result<()> {
     assert_eq!(labels, vec!["a", "b", "c"]);
     let col_b: Vec<f64> = corr.column("b")?.f64()?.into_no_null_iter().collect();
     assert_eq!(col_b, vec![1.0, 1.0, -1.0]);
+    Ok(())
+}
+
+#[test]
+fn matrix_empty_columns() -> anyhow::Result<()> {
+    let df = df!("x" => &[1.0f64, 2.0])?;
+    let corr = correlation_matrix(&df, &[])?;
+    assert_eq!(corr.shape(), (0, 0));
+    Ok(())
+}
+
+#[test]
+fn matrix_symmetry() -> anyhow::Result<()> {
+    let df = df!(
+        "a" => &[1.0f64, 2.0, 3.0],
+        "b" => &[3.0f64, 2.0, 1.0]
+    )?;
+    let corr = correlation_matrix(&df, &["a", "b"])?;
+    let ab = corr.column("b")?.f64()?.get(0).unwrap();
+    let ba = corr.column("a")?.f64()?.get(1).unwrap();
+    let aa = corr.column("a")?.f64()?.get(0).unwrap();
+    let bb = corr.column("b")?.f64()?.get(1).unwrap();
+    assert!((ab - ba).abs() < 1e-12);
+    assert!((aa - 1.0).abs() < 1e-12);
+    assert!((bb - 1.0).abs() < 1e-12);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `Correlation` variant to GUI operations
- allow selecting numeric columns and compute correlation matrix
- integrate with `parquet_examples::correlation_matrix`
- test correlation function with more cases

## Testing
- `cargo test` *(fails: `collect2: fatal error: ld terminated with signal 9 [Killed]`)*

------
https://chatgpt.com/codex/tasks/task_e_68862394e9a48332ba86e002b3d653a6