### PR TITLE
Handle unsupported cell types

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -467,7 +467,7 @@ fn set_cell_value(df: &mut DataFrame, row: usize, col: usize, value: &str) -> an
                 Ok(ca.scatter_single(vec![row as IdxSize], Some(ns))?.into_series())
             })?;
         }
-        _ => return Err(anyhow::anyhow!(format!("unsupported type: {:?}", dtype))),
+        _ => anyhow::bail!("unsupported type: {:?}", dtype),
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- return an error using `anyhow::bail!` for unsupported cell types

## Testing
- `cargo test set_cell_value_errors_on_categorical --quiet` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_688639c693b88332910040e3cc39062c