### PR TITLE
Add compression selection for Parquet writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Example reading a file:
 cargo run -- read path/to/file.parquet
 ```
 
+When writing files the `write` subcommand accepts an optional
+`--compression` flag which defaults to `snappy`:
+
+```
+cargo run -- write input.parquet output.parquet --compression gzip
+```
+
 ## Benchmarks
 
 Running `cargo bench` builds a small benchmark comparing the old per-file

--- a/src/background.rs
+++ b/src/background.rs
@@ -133,12 +133,13 @@ pub async fn read_filter_slice(
 pub async fn write_dataframe(
     mut df: DataFrame,
     path: String,
+    compression: parquet::basic::Compression,
     tx: Sender<anyhow::Result<JobUpdate>>,
 ) {
     run_with_progress(
         tx,
         move || {
-            parquet_examples::write_dataframe_to_parquet(&mut df, &path)?;
+            parquet_examples::write_dataframe_to_parquet(&mut df, &path, compression)?;
             Ok(())
         },
         |_| JobResult::Unit,

--- a/tests/filter_count.rs
+++ b/tests/filter_count.rs
@@ -1,5 +1,6 @@
 use Polars_Parquet_Learning::{background, parquet_examples};
 use polars::prelude::*;
+use parquet::basic::Compression;
 use std::sync::mpsc;
 use tempfile::tempdir;
 
@@ -19,7 +20,11 @@ fn count_filtered_rows() -> anyhow::Result<()> {
         })
         .collect();
     let mut df = df!("id" => ids, "name" => names)?;
-    parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
+    parquet_examples::write_dataframe_to_parquet(
+        &mut df,
+        file.to_str().unwrap(),
+        parquet::basic::Compression::SNAPPY,
+    )?;
 
     let count =
         parquet_examples::filter_count(file.to_str().unwrap(), &["name == \"yes\"".to_string()])?;

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -1,5 +1,6 @@
 use Polars_Parquet_Learning::{background, parquet_examples};
 use polars::prelude::*;
+use parquet::basic::Compression;
 use tempfile::tempdir;
 
 #[test]
@@ -10,7 +11,11 @@ fn paginate_multiple_pages() -> anyhow::Result<()> {
     let ids: Vec<i64> = (0..120).collect();
     let names: Vec<String> = ids.iter().map(|i| format!("n{i}")).collect();
     let mut df = df!("id" => ids, "name" => names)?;
-    parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
+    parquet_examples::write_dataframe_to_parquet(
+        &mut df,
+        file.to_str().unwrap(),
+        parquet::basic::Compression::SNAPPY,
+    )?;
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let (tx1, rx1) = std::sync::mpsc::channel();
@@ -71,7 +76,11 @@ fn paginate_filtered_pages() -> anyhow::Result<()> {
         })
         .collect();
     let mut df = df!("id" => ids, "name" => names)?;
-    parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
+    parquet_examples::write_dataframe_to_parquet(
+        &mut df,
+        file.to_str().unwrap(),
+        parquet::basic::Compression::SNAPPY,
+    )?;
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let exprs = vec!["name == \"yes\"".to_string()];
@@ -127,7 +136,11 @@ fn paginate_filtered_contains() -> anyhow::Result<()> {
     let ids: Vec<i64> = (0..120).collect();
     let names: Vec<String> = ids.iter().map(|i| format!("n{i}")).collect();
     let mut df = df!("id" => ids, "name" => names)?;
-    parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
+    parquet_examples::write_dataframe_to_parquet(
+        &mut df,
+        file.to_str().unwrap(),
+        parquet::basic::Compression::SNAPPY,
+    )?;
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let exprs = vec!["name contains \"1\"".to_string()];
@@ -185,7 +198,11 @@ fn prefetch_reuses_cache() -> anyhow::Result<()> {
     let ids: Vec<i64> = (0..50).collect();
     let names: Vec<String> = ids.iter().map(|i| format!("n{i}")).collect();
     let mut df = df!("id" => ids, "name" => names)?;
-    parquet_examples::write_dataframe_to_parquet(&mut df, file.to_str().unwrap())?;
+    parquet_examples::write_dataframe_to_parquet(
+        &mut df,
+        file.to_str().unwrap(),
+        parquet::basic::Compression::SNAPPY,
+    )?;
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let mut cache: HashMap<usize, DataFrame> = HashMap::new();


### PR DESCRIPTION
## Summary
- allow specifying compression when writing Parquet files
- expose `--compression` flag in CLI
- add GUI combo box to pick compression codec
- update docs and unit tests

## Testing
- `cargo test --color never --quiet` *(fails: linking with `cc` failed)*

 