### PR TITLE
Fix reversed histogram range

### DIFF
--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -529,7 +529,7 @@ pub fn compute_histogram(
         return (vec![0.0; bins], 0.0, 0.0);
     }
 
-    let (min, max) = match range {
+    let (mut min, mut max) = match range {
         Some(r) => r,
         None => {
             let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
@@ -537,6 +537,9 @@ pub fn compute_histogram(
             (min, max)
         }
     };
+    if min > max {
+        std::mem::swap(&mut min, &mut max);
+    }
     let step = (max - min) / bins as f64;
     let mut counts = vec![0f64; bins];
     if step == 0.0 {

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -17,3 +17,11 @@ fn histogram_constant_values() {
     assert_eq!(counts[0] as usize, values.len());
     assert!(counts[1..].iter().all(|&c| c == 0.0));
 }
+
+#[test]
+fn histogram_swaps_invalid_range() {
+    let values = vec![0.0, 1.0, 2.0, 3.0, 4.0];
+    let expected = compute_histogram(&values, 5, Some((0.0, 5.0)));
+    let reversed = compute_histogram(&values, 5, Some((5.0, 0.0)));
+    assert_eq!(expected, reversed);
+}


### PR DESCRIPTION
## Summary
- swap min and max when `compute_histogram` receives a reversed range
- test reversed range handling

## Testing
- `cargo test --no-run` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_688653f46b9883329bca76096a1eb6e3