### PR TITLE
Handle null values in correlation matrix

### DIFF
--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -359,6 +359,7 @@ pub fn reorder_columns(df: &mut DataFrame, order: &[String]) -> Result<()> {
 ///
 /// The returned [`DataFrame`] contains a `column` label column followed by
 /// each input column containing the pairwise Pearson correlation coefficients.
+/// Null values are converted to `NaN` before the calculations.
 pub fn correlation_matrix(df: &DataFrame, columns: &[&str]) -> Result<DataFrame> {
     if columns.is_empty() {
         return Ok(DataFrame::default());
@@ -370,7 +371,11 @@ pub fn correlation_matrix(df: &DataFrame, columns: &[&str]) -> Result<DataFrame>
     for &name in columns {
         let s = df.column(name)?;
         let s = s.cast(&DataType::Float64)?;
-        let vals: Vec<f64> = s.f64()?.into_no_null_iter().collect();
+        let vals: Vec<f64> = s
+            .f64()?
+            .into_iter()
+            .map(|o| o.unwrap_or(f64::NAN))
+            .collect();
         data.push(vals);
     }
 

--- a/tests/correlation.rs
+++ b/tests/correlation.rs
@@ -41,3 +41,18 @@ fn matrix_symmetry() -> anyhow::Result<()> {
     assert!((bb - 1.0).abs() < 1e-12);
     Ok(())
 }
+
+#[test]
+fn matrix_with_nulls() -> anyhow::Result<()> {
+    let df = df!(
+        "a" => &[Some(1.0f64), None, Some(3.0)],
+        "b" => &[Some(1.0f64), Some(2.0), None]
+    )?;
+    let corr = correlation_matrix(&df, &["a", "b"])?;
+    assert_eq!(corr.shape(), (2, 3));
+    let ab = corr.column("b")?.f64()?.get(0).unwrap();
+    let ba = corr.column("a")?.f64()?.get(1).unwrap();
+    assert!(ab.is_nan());
+    assert!(ba.is_nan());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- allow nulls when computing correlation matrices by mapping them to `NaN`
- document `correlation_matrix` behaviour with nulls
- test correlation matrix generation with null values

## Testing
- `cargo test --quiet` *(fails: collect2: fatal error: ld terminated with signal 9 [Killed])*

------
 