### PR TITLE
Add range validation for histogram

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1126,11 +1126,17 @@ impl eframe::App for ParquetApp {
                                 match self.plot_type {
                                     PlotType::Histogram => {
                                         let (counts, min, step) =
-                                            parquet_examples::compute_histogram(
+                                            match parquet_examples::compute_histogram(
                                                 &values,
                                                 self.hist_bins,
                                                 self.x_range,
-                                            );
+                                            ) {
+                                                Ok(v) => v,
+                                                Err(e) => {
+                                                    eprintln!("failed to compute histogram: {}", e);
+                                                    (Vec::new(), 0.0, 0.0)
+                                                }
+                                            };
                                         let bars: Vec<_> = counts
                                             .iter()
                                             .enumerate()

--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -520,12 +520,12 @@ pub fn compute_histogram(
     values: &[f64],
     bins: usize,
     range: Option<(f64, f64)>,
-) -> (Vec<f64>, f64, f64) {
+) -> Result<(Vec<f64>, f64, f64)> {
     if bins == 0 {
-        return (Vec::new(), 0.0, 0.0);
+        return Ok((Vec::new(), 0.0, 0.0));
     }
     if values.is_empty() {
-        return (vec![0.0; bins], 0.0, 0.0);
+        return Ok((vec![0.0; bins], 0.0, 0.0));
     }
 
     let (mut min, mut max) = match range {
@@ -537,7 +537,7 @@ pub fn compute_histogram(
         }
     };
     if min > max {
-        std::mem::swap(&mut min, &mut max);
+        anyhow::bail!("histogram range min is greater than max");
     }
     let step = (max - min) / bins as f64;
     let mut counts = vec![0f64; bins];
@@ -556,7 +556,7 @@ pub fn compute_histogram(
             counts[i] += 1.0;
         }
     }
-    (counts, min, step)
+    Ok((counts, min, step))
 }
 
 /// Filter rows in a Parquet file by a prefix on the `name` column.

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -3,7 +3,7 @@ use Polars_Parquet_Learning::parquet_examples::compute_histogram;
 #[test]
 fn histogram_respects_bins() {
     let values = vec![0.0, 1.0, 2.0, 3.0, 4.0];
-    let (counts, _min, _step) = compute_histogram(&values, 5, None);
+    let (counts, _min, _step) = compute_histogram(&values, 5, None).unwrap();
     assert_eq!(counts.len(), 5);
     let total: f64 = counts.iter().sum();
     assert_eq!(total as usize, values.len());
@@ -12,16 +12,15 @@ fn histogram_respects_bins() {
 #[test]
 fn histogram_constant_values() {
     let values = vec![1.0, 1.0, 1.0, 1.0];
-    let (counts, _min, _step) = compute_histogram(&values, 3, None);
+    let (counts, _min, _step) = compute_histogram(&values, 3, None).unwrap();
     assert_eq!(counts.len(), 3);
     assert_eq!(counts[0] as usize, values.len());
     assert!(counts[1..].iter().all(|&c| c == 0.0));
 }
 
 #[test]
-fn histogram_swaps_invalid_range() {
+fn histogram_invalid_range_error() {
     let values = vec![0.0, 1.0, 2.0, 3.0, 4.0];
-    let expected = compute_histogram(&values, 5, Some((0.0, 5.0)));
-    let reversed = compute_histogram(&values, 5, Some((5.0, 0.0)));
-    assert_eq!(expected, reversed);
+    let result = compute_histogram(&values, 5, Some((5.0, 0.0)));
+    assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary
- return `Result` from `compute_histogram` and error if range is reversed
- handle the error in the UI caller
- check for the error case in tests

## Testing
- `cargo check`
- `cargo test --no-run` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68865a0e944083328a1809536b170a7e