### PR TITLE
Add join, group and pivot examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # Polars DataFrame library with Parquet support
-polars = { version = "0.49.1", features = ["lazy", "parquet", "strings", "partition_by", "json", "regex"] }
+polars = { version = "0.49.1", features = ["lazy", "parquet", "strings", "partition_by", "json", "regex", "pivot"] }
 
 # Low level Parquet crate (optional when using Polars)
 parquet = "55.2"

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ common patterns:
   are collected into a `DataFrame`.
 * **`read_parquet_metadata`** – inspect low level metadata with the `parquet`
   crate without loading the entire file.
-* **`read_partitions`** – load all Parquet files from a directory pattern with a single
-  `scan_parquet` call.
+* **`read_partitions`** – load all Parquet files from a directory pattern with a single `scan_parquet` call.
+* **`join_on_key`** – join two DataFrames on a common column.
+* **`group_by_sum`** – group rows by a column and sum another column.
+* **`pivot_wider`** – pivot data from long to wide form.
 
 See [`src/parquet_examples.rs`](src/parquet_examples.rs) for implementation
 details and tests for each use case.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
-use polars_parquet_learning::parquet_examples;
+use crate::parquet_examples;
 use anyhow::Result;
-use polars_parquet_learning::xml_to_parquet;
+use crate::xml_to_parquet;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 /// Top level command line arguments

--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -591,6 +591,31 @@ pub fn filter_with_expr(path: &str, expr: &str) -> Result<DataFrame> {
     Ok(lf.filter(filter).collect()?)
 }
 
+/// Join two [`DataFrame`]s on a key column using an inner join.
+pub fn join_on_key(left: &DataFrame, right: &DataFrame, key: &str) -> Result<DataFrame> {
+    Ok(left.join(right, [key], [key], JoinArgs::from(JoinType::Inner), None)?)
+}
+
+/// Group by `group` and compute the sum of `values`.
+pub fn group_by_sum(df: &DataFrame, group: &str, values: &str) -> Result<DataFrame> {
+    Ok(df.group_by([group])?.select([values]).sum()?)
+}
+
+/// Pivot long-form data into a wide layout.
+pub fn pivot_wider(df: &DataFrame, index: &str, columns: &str, values: &str) -> Result<DataFrame> {
+    use polars::lazy::frame::pivot::pivot_stable;
+
+    Ok(pivot_stable(
+        df,
+        [columns],
+        Some([index]),
+        Some([values]),
+        true,
+        Some(first()),
+        None,
+    )?)
+}
+
 fn parse_simple_expr(s: &str) -> Result<Expr> {
     let parts: Vec<String> = shlex::Shlex::new(s).collect();
     if parts.len() != 3 {

--- a/tests/join_group_pivot.rs
+++ b/tests/join_group_pivot.rs
@@ -1,0 +1,41 @@
+use Polars_Parquet_Learning::parquet_examples::{join_on_key, group_by_sum, pivot_wider};
+use polars::prelude::*;
+
+#[test]
+fn join_two_frames() -> anyhow::Result<()> {
+    let df1 = df!("id" => &[1i64,2,3], "a" => &[10i64,20,30])?;
+    let df2 = df!("id" => &[2i64,3,4], "b" => &[200i64,300,400])?;
+    let joined = join_on_key(&df1, &df2, "id")?;
+    assert_eq!(joined.height(), 2);
+    let ids: Vec<i64> = joined.column("id")?.i64()?.into_no_null_iter().collect();
+    assert_eq!(ids, vec![2,3]);
+    Ok(())
+}
+
+#[test]
+fn group_and_sum() -> anyhow::Result<()> {
+    let df = df!("cat" => ["x","x","y"], "val" => [1i64,2,3])?;
+    let grouped = group_by_sum(&df, "cat", "val")?;
+    assert_eq!(grouped.height(), 2);
+    let vals: Vec<i64> = grouped.column("val_sum")?.i64()?.into_no_null_iter().collect();
+    let cats: Vec<&str> = grouped.column("cat")?.str()?.into_no_null_iter().collect();
+    assert_eq!(cats.len(), 2);
+    assert!(cats.contains(&"x"));
+    assert!(cats.contains(&"y"));
+    assert_eq!(vals.iter().sum::<i64>(), 6);
+    Ok(())
+}
+
+#[test]
+fn pivot_to_wide() -> anyhow::Result<()> {
+    let df = df!(
+        "id" => &[1i64,1,2],
+        "var" => &["A","B","A"],
+        "val" => &[10i64,20,30]
+    )?;
+    let wide = pivot_wider(&df, "id", "var", "val")?;
+    assert_eq!(wide.height(), 2);
+    assert!(wide.column("A").is_ok());
+    assert!(wide.column("B").is_ok());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement join_on_key, group_by_sum and pivot_wider helper functions
- cover them with unit tests
- mention the new helpers in the README
- enable the `pivot` feature for Polars
- fix self-crate imports in CLI module

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_688667a172408332864f5a27dcba8461