### PR TITLE
Resolve build warnings and rename crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,30 +3,6 @@
 version = 4
 
 [[package]]
-name = "Polars_Parquet_Learning"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "criterion",
- "eframe",
- "egui",
- "egui_extras",
- "egui_plot",
- "parquet",
- "polars",
- "quick-xml 0.38.0",
- "rfd",
- "serde",
- "serde_derive",
- "serde_json",
- "shlex",
- "tempfile",
- "tokio",
-]
-
-[[package]]
 name = "ab_glyph"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3972,6 +3948,30 @@ dependencies = [
  "slotmap",
  "stacker",
  "version_check",
+]
+
+[[package]]
+name = "polars_parquet_learning"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "criterion",
+ "eframe",
+ "egui",
+ "egui_extras",
+ "egui_plot",
+ "parquet",
+ "polars",
+ "quick-xml 0.38.0",
+ "rfd",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "shlex",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Polars_Parquet_Learning"
+name = "polars_parquet_learning"
 version = "0.1.0"
 edition = "2024"
 
@@ -38,7 +38,7 @@ serde_json = "1.0"
 egui_plot = { version = "0.33" }
 
 [[bin]]
-name = "Polars_Parquet_Learning"
+name = "polars_parquet_learning"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cargo run
 ```
 
 For release builds use `cargo build --release` followed by the generated binary
-in `target/release/Polars_Parquet_Learning`.
+in `target/release/polars_parquet_learning`.
 
 ## Example workflow
 

--- a/src/parquet_examples.rs
+++ b/src/parquet_examples.rs
@@ -528,7 +528,7 @@ pub fn compute_histogram(
         return Ok((vec![0.0; bins], 0.0, 0.0));
     }
 
-    let (mut min, mut max) = match range {
+    let (min, max) = match range {
         Some(r) => r,
         None => {
             let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
@@ -598,7 +598,13 @@ pub fn join_on_key(left: &DataFrame, right: &DataFrame, key: &str) -> Result<Dat
 
 /// Group by `group` and compute the sum of `values`.
 pub fn group_by_sum(df: &DataFrame, group: &str, values: &str) -> Result<DataFrame> {
-    Ok(df.group_by([group])?.select([values]).sum()?)
+    Ok(
+        df.clone()
+            .lazy()
+            .group_by([col(group)])
+            .agg([col(values).sum()])
+            .collect()?,
+    )
 }
 
 /// Pivot long-form data into a wide layout.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,6 @@
 use polars::prelude::*;
 use std::fs::File;
-use Polars_Parquet_Learning::cli::{
+use polars_parquet_learning::cli::{
     self, Cli, Commands, ReadArgs, WriteArgs, CompressionArg, XmlArgs,
 };
 use parquet::basic::{Compression, GzipLevel};
@@ -59,7 +59,7 @@ fn cli_write_with_compression() {
     };
     cli::run(cli).unwrap();
     let meta =
-        Polars_Parquet_Learning::parquet_examples::read_parquet_metadata(output.to_str().unwrap())
+        polars_parquet_learning::parquet_examples::read_parquet_metadata(output.to_str().unwrap())
             .unwrap();
     assert_eq!(
         meta.row_group(0)

--- a/tests/column_ops.rs
+++ b/tests/column_ops.rs
@@ -1,4 +1,4 @@
-use Polars_Parquet_Learning::parquet_examples::{drop_column, rename_column, reorder_columns};
+use polars_parquet_learning::parquet_examples::{drop_column, rename_column, reorder_columns};
 use polars::prelude::*;
 
 #[test]

--- a/tests/correlation.rs
+++ b/tests/correlation.rs
@@ -1,4 +1,4 @@
-use Polars_Parquet_Learning::parquet_examples::correlation_matrix;
+use polars_parquet_learning::parquet_examples::correlation_matrix;
 use polars::prelude::*;
 
 #[test]

--- a/tests/filter_count.rs
+++ b/tests/filter_count.rs
@@ -1,4 +1,4 @@
-use Polars_Parquet_Learning::{background, parquet_examples};
+use polars_parquet_learning::{background, parquet_examples};
 use polars::prelude::*;
 use parquet::basic::Compression;
 use std::sync::mpsc;

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -1,4 +1,4 @@
-use Polars_Parquet_Learning::parquet_examples::compute_histogram;
+use polars_parquet_learning::parquet_examples::compute_histogram;
 
 #[test]
 fn histogram_respects_bins() {

--- a/tests/join_group_pivot.rs
+++ b/tests/join_group_pivot.rs
@@ -1,4 +1,4 @@
-use Polars_Parquet_Learning::parquet_examples::{join_on_key, group_by_sum, pivot_wider};
+use polars_parquet_learning::parquet_examples::{join_on_key, group_by_sum, pivot_wider};
 use polars::prelude::*;
 
 #[test]

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -1,4 +1,4 @@
-use Polars_Parquet_Learning::{background, parquet_examples};
+use polars_parquet_learning::{background, parquet_examples};
 use parquet::basic::Compression;
 use polars::prelude::*;
 use tempfile::tempdir;

--- a/tests/read_parquet_error.rs
+++ b/tests/read_parquet_error.rs
@@ -1,6 +1,6 @@
 use polars::prelude::*;
 use tempfile::tempdir;
-use Polars_Parquet_Learning::xml_examples;
+use polars_parquet_learning::xml_examples;
 
 #[test]
 fn read_parquet_with_nulls_returns_error() -> anyhow::Result<()> {

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -1,4 +1,4 @@
-use Polars_Parquet_Learning::search::{find_matches, next_index, prev_index};
+use polars_parquet_learning::search::{find_matches, next_index, prev_index};
 
 #[test]
 fn navigate_matches_cycles() {

--- a/tests/summary.rs
+++ b/tests/summary.rs
@@ -1,5 +1,5 @@
 use polars::prelude::*;
-use Polars_Parquet_Learning::parquet_examples::summarize_dataframe;
+use polars_parquet_learning::parquet_examples::summarize_dataframe;
 
 #[test]
 fn summary_reports_size() -> anyhow::Result<()> {

--- a/tests/xml_dynamic.rs
+++ b/tests/xml_dynamic.rs
@@ -1,5 +1,5 @@
 use polars::prelude::*;
-use Polars_Parquet_Learning::xml_dynamic::{parse_any_xml, value_to_tables};
+use polars_parquet_learning::xml_dynamic::{parse_any_xml, value_to_tables};
 
 #[test]
 fn parse_sample_xml() -> anyhow::Result<()> {

--- a/tests/xml_round_trip.rs
+++ b/tests/xml_round_trip.rs
@@ -1,6 +1,6 @@
 use tempfile::tempdir;
 
-use Polars_Parquet_Learning::{xml_examples, xml_to_parquet};
+use polars_parquet_learning::{xml_examples, xml_to_parquet};
 
 #[test]
 fn xml_examples_round_trip() -> anyhow::Result<()> {

--- a/tests/xml_to_parquet.rs
+++ b/tests/xml_to_parquet.rs
@@ -1,7 +1,7 @@
 use polars::prelude::*;
 use tempfile::tempdir;
 
-use Polars_Parquet_Learning::xml_to_parquet::{flatten_to_tables, parse_xml, write_tables};
+use polars_parquet_learning::xml_to_parquet::{flatten_to_tables, parse_xml, write_tables};
 
 #[test]
 fn xml_round_trip() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- rename crate and binary to `polars_parquet_learning`
- update references in code, tests and docs
- replace deprecated API usages
- remove unnecessary mutable bindings and imports
- adjust group-by implementation to use lazy API

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_688684572fe88332998376454765192a